### PR TITLE
Get single policy endpoint - policy overview

### DIFF
--- a/app/controllers/api/v1/climate_policy/policies_controller.rb
+++ b/app/controllers/api/v1/climate_policy/policies_controller.rb
@@ -6,6 +6,13 @@ module Api
           render json: ::ClimatePolicy::Policy.all,
                  each_serializer: Api::V1::ClimatePolicy::PolicySerializer
         end
+
+        def show
+          policy = ::ClimatePolicy::Policy.find_by!(code: params[:code])
+
+          render json: policy,
+                 serializer: Api::V1::ClimatePolicy::PolicySerializer
+        end
       end
     end
   end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -8,7 +8,7 @@
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
-#  role                   :string           not null
+#  role                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #

--- a/app/models/climate_policy/policy.rb
+++ b/app/models/climate_policy/policy.rb
@@ -4,7 +4,7 @@
 #
 #  id                   :bigint(8)        not null, primary key
 #  authority            :text
-#  category             :string           not null
+#  sector               :string           not null
 #  code                 :string           not null
 #  description          :text
 #  policy_type          :string           not null
@@ -18,5 +18,6 @@ module ClimatePolicy
     self.table_name = 'climate_policies'
 
     validates_presence_of :sector, :code, :policy_type, :title
+    validates :code, uniqueness: true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1, defaults: { format: :json } do
       namespace :climate_policy do
-        resources :policies, only: [:index]
+        resources :policies, only: [:index, :show], param: :code
       end
     end
   end

--- a/db/migrate/20181205165349_add_unique_index_on_code_to_climate_policies.rb
+++ b/db/migrate/20181205165349_add_unique_index_on_code_to_climate_policies.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnCodeToClimatePolicies < ActiveRecord::Migration[5.2]
+  def change
+    add_index :climate_policies, :code, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_04_131137) do
+ActiveRecord::Schema.define(version: 2018_12_05_165349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,19 +36,6 @@ ActiveRecord::Schema.define(version: 2018_12_04_131137) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "admin_users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.string "role", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_admin_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
-  end
-
   create_table "climate_policies", force: :cascade do |t|
     t.string "sector", null: false
     t.string "code", null: false
@@ -58,6 +45,7 @@ ActiveRecord::Schema.define(version: 2018_12_04_131137) do
     t.text "description"
     t.boolean "tracking"
     t.text "tracking_description"
+    t.index ["code"], name: "index_climate_policies_on_code", unique: true
   end
 
   create_table "datasets", force: :cascade do |t|

--- a/db/secondbase/schema.rb
+++ b/db/secondbase/schema.rb
@@ -21,9 +21,9 @@ ActiveRecord::Schema.define(version: 2018_11_08_100120) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.string "role", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "role"
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/api/v1/climate_policy/policies_controller_spec.rb
+++ b/spec/controllers/api/v1/climate_policy/policies_controller_spec.rb
@@ -18,5 +18,22 @@ describe Api::V1::ClimatePolicy::PoliciesController, type: :controller do
         expect(parsed_body.length).to eq(3)
       end
     end
+
+    describe 'GET show' do
+      let!(:policy) {
+        FactoryBot.create(:climate_policy, code: 'ECBC')
+      }
+
+      it 'returns a successful 200 response' do
+        get :show, params: {code: 'ECBC'}, format: :json
+        expect(response).to be_successful
+      end
+
+      it 'list policy by code' do
+        get :show, params: {code: 'ECBC'}, format: :json
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body).to include('code' => 'ECBC')
+      end
+    end
   end
 end

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -8,7 +8,7 @@
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
-#  role                   :string           not null
+#  role                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #

--- a/spec/factories/climate_policy.rb
+++ b/spec/factories/climate_policy.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :climate_policy, class: 'ClimatePolicy::Policy' do
     sector { 'Energy' }
-    code { 'ECBC' }
+    sequence(:code) { |n| "code_#{n}" }
     policy_type { 'Policy Instrument' }
     title { 'Energy Conservation Building Code' }
     authority { 'Bureau of Energy Efficiency and Ministry of Power' }

--- a/spec/models/climate_policy_spec.rb
+++ b/spec/models/climate_policy_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe ClimatePolicy::Policy, type: :model do
     expect(subject).to have(1).errors_on(:title)
   end
 
+  it 'should be invalid when code is taken' do
+    FactoryBot.create(:climate_policy, code: 'code')
+    subject.code = 'code'
+    expect(
+      subject
+    ).to have(1).errors_on(:code)
+  end
+
   it 'should be valid' do
     expect(subject).to be_valid
   end


### PR DESCRIPTION
Code for a policy should be unique so we can use it to get the single policy from API `api/v1/climate_policy/policies/ECBC`. This way even if a new data is imported, frontend does not have to know internal ids to get the data and old links should work.