### PR TITLE
climate_finance: import, api endpoint

### DIFF
--- a/app/admin/india_platform/climate_finance.rb
+++ b/app/admin/india_platform/climate_finance.rb
@@ -1,0 +1,71 @@
+ActiveAdmin.register_page 'India Platform Climate Finance' do
+  include DataUploader::SharedAdmin
+
+  section_name = 'climate_finance'
+  platform_name = 'india_platform'
+
+  controller do
+    def section_name
+      'climate_finance'
+    end
+
+    def platform_name
+      'india_platform'
+    end
+
+    def s3_folder_path
+      "#{CW_FILES_PREFIX}climate_finance"
+    end
+
+    def path
+      admin_india_platform_climate_finance_path
+    end
+
+    def section
+      section_repository.filter_by_section_and_platform(
+        section_name,
+        platform_name
+      )
+    end
+
+    def import_worker
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportClimateFinances', current_admin_user.email)
+    end
+
+    def section_repository
+      @section_repository ||= DataUploader::Repositories::SectionRepository.new
+    end
+
+    def dataset_repository
+      @dataset_repository ||= DataUploader::Repositories::DatasetRepository.new
+    end
+  end
+
+  menu parent: 'India Platform',
+       label: section_name.split('_').map(&:capitalize).join(' '),
+       if: proc { DataUploader::Helpers::Ability.can_view?(platform_name) }
+
+  section_proc = proc {
+    DataUploader::Repositories::SectionRepository.new.filter_by_section_and_platform(
+      section_name,
+      platform_name
+    )
+  }
+
+  datasets_proc = proc {
+    DataUploader::Repositories::DatasetRepository.new.filter_by_section(section_proc.call.id)
+  }
+
+  content do
+    render partial: 'data_uploader/admin/form_upload_datasets', locals: {
+      datasets: datasets_proc.call,
+      upload_path: admin_india_platform_climate_finance_upload_datafile_path,
+      download_path: admin_india_platform_climate_finance_download_datafiles_path,
+      download_single_data_file_path:
+          admin_india_platform_climate_finance_download_datafile_path,
+      import_path: admin_india_platform_climate_finance_run_importer_path,
+      import_button_disabled: section_proc.call.worker_logs.started.any?,
+      logs: section_proc.call.worker_logs.order(created_at: :desc)
+    }
+  end
+end

--- a/app/controllers/api/v1/climate_finance_controller.rb
+++ b/app/controllers/api/v1/climate_finance_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    class ClimateFinanceController < ApiController
+      def index
+        finances = ClimateFinance.all
+
+        respond_to do |format|
+          format.json do
+            render json: finances,
+                   each_serializer: Api::V1::ClimateFinanceSerializer
+          end
+          format.csv { render csv: finances }
+        end
+      end
+    end
+  end
+end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -8,7 +8,7 @@
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
-#  role                   :string           not null
+#  role                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #

--- a/app/models/climate_finance.rb
+++ b/app/models/climate_finance.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: climate_finances
+#
+#  id         :bigint(8)        not null, primary key
+#  source     :string           not null
+#  unit       :string           not null
+#  value      :float            not null
+#  year       :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class ClimateFinance < ApplicationRecord
+  include ClimateWatchEngine::GenericToCsv
+
+  validates_presence_of :source, :year, :unit, :value
+end

--- a/app/models/socioeconomic/indicator.rb
+++ b/app/models/socioeconomic/indicator.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: socioeconomic_indicators
+#
+#  id         :bigint(8)        not null, primary key
+#  category   :string
+#  code       :string           not null
+#  definition :string
+#  name       :string           not null
+#  unit       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_socioeconomic_indicators_on_code  (code) UNIQUE
+#
+
 module Socioeconomic
   class Indicator < ApplicationRecord
     validates_presence_of :name, :code, :unit

--- a/app/models/socioeconomic/value.rb
+++ b/app/models/socioeconomic/value.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: socioeconomic_values
+#
+#  id           :bigint(8)        not null, primary key
+#  category     :string
+#  source       :string
+#  values       :jsonb
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  indicator_id :bigint(8)
+#  location_id  :bigint(8)
+#
+# Indexes
+#
+#  index_socioeconomic_values_on_indicator_id  (indicator_id)
+#  index_socioeconomic_values_on_location_id   (location_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (indicator_id => socioeconomic_indicators.id) ON DELETE => cascade
+#  fk_rails_...  (location_id => locations.id) ON DELETE => cascade
+#
+
 module Socioeconomic
   class Value < ApplicationRecord
     include ClimateWatchEngine::GenericToCsv

--- a/app/serializers/api/v1/climate_finance_serializer.rb
+++ b/app/serializers/api/v1/climate_finance_serializer.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class ClimateFinanceSerializer < ActiveModel::Serializer
+      attributes :source, :year, :value, :unit
+    end
+  end
+end

--- a/app/services/import_climate_finances.rb
+++ b/app/services/import_climate_finances.rb
@@ -1,0 +1,45 @@
+class ImportClimateFinances
+  include ClimateWatchEngine::CSVImporter
+
+  headers :source, :year, :unit, :value
+
+  DATA_FILEPATH = "#{CW_FILES_PREFIX}climate_finance/climate_finance.csv".freeze
+
+  def call
+    return unless all_headers_valid?
+
+    ActiveRecord::Base.transaction do
+      cleanup
+      import_data
+    end
+  end
+
+  private
+
+  def all_headers_valid?
+    valid_headers?(csv, DATA_FILEPATH, headers)
+  end
+
+  def cleanup
+    ClimateFinance.delete_all
+  end
+
+  def import_data
+    import_each_with_logging(csv, DATA_FILEPATH) do |row|
+      ClimateFinance.create!(climate_finance_attributes(row))
+    end
+  end
+
+  def climate_finance_attributes(row)
+    {
+      source: row[:source],
+      year: row[:year]&.to_i,
+      unit: row[:unit],
+      value: row[:value]&.to_f
+    }
+  end
+
+  def csv
+    @csv ||= S3CSVReader.read(DATA_FILEPATH)
+  end
+end

--- a/config/data_uploader.yml
+++ b/config/data_uploader.yml
@@ -28,6 +28,10 @@ platforms:
           - indicators
           - values
           - sectoral_info
+      - name: climate_finance
+        importer: ImportClimateFinances
+        datasets:
+          - climate_finance
       - name: metadata
         importer: ImportDataSources
         datasets:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1, defaults: { format: :json } do
       resources :metadata, only: [:index]
+      resources :climate_finance, only: [:index]
       namespace :climate_policy do
         resources :policies, only: [:index, :show], param: :code
         resources :sources, only: [:index]

--- a/db/migrate/20190121162127_create_climate_finances.rb
+++ b/db/migrate/20190121162127_create_climate_finances.rb
@@ -1,0 +1,12 @@
+class CreateClimateFinances < ActiveRecord::Migration[5.2]
+  def change
+    create_table :climate_finances do |t|
+      t.string :source, null: false
+      t.integer :year, null: false
+      t.float :value, null: false
+      t.string :unit, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_03_104433) do
+ActiveRecord::Schema.define(version: 2019_01_21_162127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,15 @@ ActiveRecord::Schema.define(version: 2019_01_03_104433) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "climate_finances", force: :cascade do |t|
+    t.string "source", null: false
+    t.integer "year", null: false
+    t.float "value", null: false
+    t.string "unit", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "climate_policy_indicators", force: :cascade do |t|

--- a/db/secondbase/schema.rb
+++ b/db/secondbase/schema.rb
@@ -21,9 +21,9 @@ ActiveRecord::Schema.define(version: 2018_11_08_100120) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.string "role", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "role"
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -6,6 +6,7 @@ namespace :db do
     Rake::Task['climate_policies:import'].invoke
     Rake::Task['data_sources:import'].invoke
     Rake::Task['socioeconomic:import'].invoke
+    Rake::Task['climate_finance:import'].invoke
     puts 'All done!'
   end
 end

--- a/lib/tasks/import_climate_finance.rake
+++ b/lib/tasks/import_climate_finance.rake
@@ -1,0 +1,8 @@
+namespace :climate_finance do
+  desc 'Imports climate finance data'
+  task import: :environment do
+    TimedLogger.log('import climate finance data') do
+      ImportClimateFinances.new.call
+    end
+  end
+end

--- a/spec/controllers/api/v1/climate_finance_controller_spec.rb
+++ b/spec/controllers/api/v1/climate_finance_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Api::V1::ClimateFinanceController, type: :controller do
+  context do
+    let!(:climate_finance) {
+      FactoryBot.create_list(:climate_finance, 3)
+    }
+
+    describe 'GET index' do
+      it 'returns a successful 200 response' do
+        get :index, format: :json
+        expect(response).to be_successful
+      end
+
+      it 'lists all climate finances' do
+        get :index, format: :json
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -8,7 +8,7 @@
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
-#  role                   :string           not null
+#  role                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #

--- a/spec/factories/climate_finance.rb
+++ b/spec/factories/climate_finance.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :climate_finance do
+    source { 'CIFs' }
+    year { 2014 }
+    value { 1000 }
+    unit { 'USD million' }
+  end
+end

--- a/spec/models/cliamate_finance_spec.rb
+++ b/spec/models/cliamate_finance_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ClimateFinance, type: :model do
+  it 'should be invalid when source not present' do
+    expect(
+      FactoryBot.build(:climate_finance, source: nil)
+    ).to have(1).errors_on(:source)
+  end
+
+  it 'should be invalid when year not present' do
+    expect(
+      FactoryBot.build(:climate_finance, year: nil)
+    ).to have(1).errors_on(:year)
+  end
+
+  it 'should be invalid when unit not present' do
+    expect(
+      FactoryBot.build(:climate_finance, unit: nil)
+    ).to have(1).errors_on(:unit)
+  end
+
+  it 'should be invalid when value not present' do
+    expect(
+      FactoryBot.build(:climate_finance, value: nil)
+    ).to have(1).errors_on(:value)
+  end
+
+  it 'should be valid' do
+    expect(FactoryBot.build(:climate_finance)).to be_valid
+  end
+end

--- a/spec/services/import_climate_finances_spec.rb
+++ b/spec/services/import_climate_finances_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+correct_files = {
+  ImportClimateFinances::DATA_FILEPATH => <<~END_OF_CSV,
+    year,source,unit,value
+    2013,CIFs,USD million,299.91
+    2014,CIFs,USD million,25
+  END_OF_CSV
+}
+missing_headers = correct_files.merge(
+  ImportClimateFinances::DATA_FILEPATH => <<~END_OF_CSV,
+    source,unit,value
+    2013,CIFs,USD million,299.91
+    2014,CIFs,USD million,25
+  END_OF_CSV
+)
+
+RSpec.describe ImportClimateFinances do
+  let(:importer) { ImportClimateFinances.new }
+
+  after :all do
+    Aws.config[:s3] = {
+      stub_responses: nil
+    }
+  end
+
+  context 'when file is correct' do
+    before :all do
+      stub_with_files(correct_files)
+    end
+
+    subject { importer.call }
+
+    it 'Creates new climate finance records' do
+      expect { subject }.to change { ClimateFinance.count }.by(2)
+    end
+
+    describe 'Imported record' do
+      before { importer.call }
+
+      subject { ClimateFinance.find_by(source: 'CIFs') }
+
+      it 'has all attributes populated' do
+        subject.attributes.each do |attr, value|
+          expect(value).not_to be_nil, "attribute #{attr} expected to not be nil"
+        end
+      end
+    end
+  end
+
+  context 'when headers are missing' do
+    before :all do
+      stub_with_files(missing_headers)
+    end
+
+    it 'does not create any record' do
+      expect { importer.call }.to change { ClimateFinance.count }.by(0)
+    end
+
+    it 'has missing headers errors' do
+      importer.call
+      expect(importer.errors.length).to eq(1)
+      expect(importer.errors.first).to include(type: :missing_header)
+    end
+  end
+end


### PR DESCRIPTION
Importing climate finance data and creating endpoint `api/v1/climate_finance`

```
[
  {
    source: "CIFs",
    year: 2013,
    value: 299.91,
    unit: "USD million"
  },
  {
    source: "CIFs",
    year: 2014,
    value: 25,
    unit: "USD million"
  },
  {
    source: "CIFs",
    year: 2015,
    value: 125,
    unit: "USD million"
  }
]
```

Migrate and import all the data

```
bundle exec rake db:migrate
bundle exec rake db:admin_boilerplate:create
bundle exec rake db:import
```


