### PR TITLE
Pathways section - Use code from CW and tweak it

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 COUNTRY_ISO=IND
 API_URL=http://localhost:3000/api/v1
 CW_API_URL=https://climate-watch.vizzuality.com/api/v1
+ESP_API_URL=https://data.emissionspathways.org/api/v1
 POSTGRES_URL=postgresql://postgres@localhost/cw-india_development
 SHARED_POSTGRES_URL=
 GOOGLE_ANALYTICS_ID=

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ For Thunk actions a slim wrapper around `createActions` is used, this allows us 
 Reducers inside a module are simple pure functions, no switch case is even present.
 The reducers file exports an object which keys are the actions constants and the value is the reducer that will react to that dispatched action.
 
-The exported actions are used for the keys since `redux-actions` returns the action constant when calling the `.toString()` method in the action creator.
+The exported actions are used for the keys since `redux-tools` returns the action constant when calling the `.toString()` method in the action creator.
 
 ### Modules boilerplate generator
 
@@ -150,7 +150,7 @@ The application actions file is free to import/export every module's actions ind
 ### App Reducers
 
 In the app reducers we will import all module's reducers and bind them to a key in the store using a `handleActions` wrapper.
-This wrapper uses `redux-actions`'s `handleActions` and glues all the individual reducers together to the matching actions.
+This wrapper uses `redux-tools`'s `handleActions` and glues all the individual reducers together to the matching actions.
 
 ### Domain description
 

--- a/app/javascript/app/components/section-title/section-title-component.jsx
+++ b/app/javascript/app/components/section-title/section-title-component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import iconInfo from 'assets/icons/info';
 import { Icon } from 'cw-components';
+import { TabletLandscape, TabletPortraitOnly } from 'components/responsive';
 import styles from './section-title-styles.scss';
 
 class SectionTitle extends PureComponent {
@@ -10,6 +11,15 @@ class SectionTitle extends PureComponent {
     const { setOpen } = this.props;
     setOpen(true);
   };
+
+  renderExtraContent() {
+    const { extraContent } = this.props;
+    return (
+      <div className={styles.extraContent}>
+        {extraContent}
+      </div>
+    );
+  }
 
   render() {
     const {
@@ -19,8 +29,7 @@ class SectionTitle extends PureComponent {
       infoButton,
       className,
       description,
-      noMarginBottom,
-      extraContent
+      noMarginBottom
     } = this.props;
     return (
       <React.Fragment>
@@ -50,7 +59,9 @@ class SectionTitle extends PureComponent {
             </button>
               )
           }
-          {extraContent}
+          <TabletLandscape>
+            {this.renderExtraContent()}
+          </TabletLandscape>
         </div>
         {
           description &&
@@ -61,6 +72,9 @@ class SectionTitle extends PureComponent {
               />
             )
         }
+        <TabletPortraitOnly>
+          {this.renderExtraContent()}
+        </TabletPortraitOnly>
       </React.Fragment>
     );
   }

--- a/app/javascript/app/components/section-title/section-title-styles.scss
+++ b/app/javascript/app/components/section-title/section-title-styles.scss
@@ -43,3 +43,12 @@
 .sectionContainerNoMarginBottom {
   margin-bottom: 0;
 }
+
+.extraContent {
+  margin-bottom: $gutter-padding;
+
+  @media #{$tablet-landscape} {
+    margin-bottom: 0;
+    align-self: center;
+  }
+}

--- a/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-actions.js
+++ b/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-actions.js
@@ -1,0 +1,46 @@
+import { createAction, createThunkAction } from 'redux-tools';
+import isEmpty from 'lodash/isEmpty';
+import { ESPAPI } from 'services/api';
+import { COUNTRY_CONTEXT } from 'router';
+
+const updateFiltersSelected = createAction(COUNTRY_CONTEXT);
+
+const findAvailableModelsInit = createAction('findAvailableModelsInit');
+const findAvailableModelsReady = createAction('findAvailableModelsReady');
+const findAvailableModelsFail = createAction('findAvailableModelsFail');
+
+const findAvailableModels = createThunkAction(
+  'findAvailableModels',
+  locationId => (dispatch, state) => {
+    const { espGraph } = state();
+    if (isEmpty(espGraph.locations) || !espGraph.locations[locationId]) {
+      dispatch(findAvailableModelsInit());
+      ESPAPI
+        .get('models', { location: locationId, time_series: true })
+        .then(data => {
+          if (data) {
+            dispatch(
+              findAvailableModelsReady({
+                locationId,
+                modelIds: data.map(d => d.id)
+              })
+            );
+          } else {
+            dispatch(findAvailableModelsReady({ locationId, modelIds: {} }));
+          }
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(findAvailableModelsFail());
+        });
+    }
+  }
+);
+
+export default {
+  findAvailableModels,
+  findAvailableModelsInit,
+  findAvailableModelsReady,
+  findAvailableModelsFail,
+  updateFiltersSelected
+};

--- a/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-component.jsx
+++ b/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import SectionTitle from 'components/section-title';
+import InfoDownloadToolbox from 'components/info-download-toolbox';
 import PropTypes from 'prop-types';
 import EspLocationsProvider from 'providers/esp-locations-provider';
 import EspModelsProvider from 'providers/esp-models-provider';
@@ -123,6 +124,11 @@ class EmissionPathways extends PureComponent {
                   onValueChange={option =>
                     handleSelectorChange(option, 'indicator')}
                   value={filtersSelected.indicator}
+                />
+                <InfoDownloadToolbox
+                  className={{ buttonWrapper: styles.buttonWrapper }}
+                  slugs=""
+                  downloadUri=""
                 />
               </div>
             </div>

--- a/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-component.jsx
+++ b/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-component.jsx
@@ -1,0 +1,173 @@
+import React, { PureComponent } from 'react';
+import SectionTitle from 'components/section-title';
+import PropTypes from 'prop-types';
+import EspLocationsProvider from 'providers/esp-locations-provider';
+import EspModelsProvider from 'providers/esp-models-provider';
+import EspScenariosProvider from 'providers/esp-scenarios-provider';
+import EspIndicatorsProvider from 'providers/esp-indicators-provider';
+import EspTimeSeriesProvider from 'providers/esp-time-series-provider';
+import { Dropdown, Chart, Button, Icon } from 'cw-components';
+import openInNew from 'assets/icons/open-in-new';
+import buttonThemes from 'styles/themes/button';
+import iconThemes from 'styles/themes/icon';
+import cx from 'classnames';
+import styles from './emission-pathways-styles.scss';
+
+const CW_PATHWAYS_LINK = 'https://www.climatewatchdata.org/pathways';
+
+class EmissionPathways extends PureComponent {
+  renderCustomMessage() {
+    const { filtersSelected } = this.props;
+    const getName = attribute =>
+      filtersSelected[attribute] && filtersSelected[attribute].label;
+    const unavailableIndicatorName = getName('indicator')
+      ? ` , ${getName('indicator')}`
+      : '';
+    return `${getName('location')} doesn't have any data for ${getName(
+      'model'
+    )}${unavailableIndicatorName}. `;
+  }
+
+  render() {
+    const {
+      data,
+      config,
+      loading,
+      error,
+      filtersLoading,
+      filtersOptions,
+      filtersSelected,
+      handleSelectorChange,
+      handleModelChange,
+      handleLegendChange
+    } = this.props;
+    const needsTimeSeries = filtersSelected &&
+      filtersSelected.location &&
+      filtersSelected.model;
+    const filtersDisabled = filtersLoading.indicators ||
+      filtersLoading.timeseries ||
+      filtersLoading.models;
+    return (
+      <div className={styles.page}>
+        <SectionTitle
+          title="Emission pathways"
+          description="Emission pathways description"
+          extraContent={
+            (
+              <Button
+                theme={{
+                  button: cx(buttonThemes.yellow, styles.powerExplorerButton)
+                }}
+                link={{
+                  type: 'a',
+                  props: { href: CW_PATHWAYS_LINK, target: '_blank' }
+                }}
+              >
+                Explore pathways
+                <Icon icon={openInNew} theme={{ icon: iconThemes.openInNew }} />
+              </Button>
+            )
+          }
+        />
+        <div className={styles.wrapper}>
+          <div className={styles.content}>
+            <EspModelsProvider />
+            <EspScenariosProvider />
+            <EspIndicatorsProvider />
+            <EspLocationsProvider withTimeSeries />
+            {
+              needsTimeSeries &&
+                (
+                  <EspTimeSeriesProvider
+                    location={filtersSelected.location.value}
+                    model={filtersSelected.model.value}
+                  />
+                )
+            }
+            <div className="grid-column-item">
+              <div className={styles.selectorsWrapper}>
+                <Dropdown
+                  label="Model"
+                  options={filtersOptions.models}
+                  onValueChange={handleModelChange}
+                  disabled={filtersLoading.location}
+                  value={filtersSelected.model}
+                  hideResetButton
+                />
+                <Dropdown
+                  label="Category"
+                  placeholder="Select a category"
+                  options={filtersOptions.category}
+                  hideResetButton
+                  disabled={filtersDisabled}
+                  onValueChange={option =>
+                    handleSelectorChange(option, 'category')}
+                  value={filtersSelected.category}
+                />
+                <Dropdown
+                  label="Subcategory"
+                  placeholder="Select a subcategory"
+                  options={filtersOptions.subcategory}
+                  hideResetButton
+                  disabled={filtersDisabled}
+                  onValueChange={option =>
+                    handleSelectorChange(option, 'subcategory')}
+                  value={filtersSelected.subcategory}
+                />
+                <Dropdown
+                  label="Indicator"
+                  placeholder="Select an indicator"
+                  options={filtersOptions.indicators}
+                  hideResetButton
+                  disabled={filtersDisabled}
+                  onValueChange={option =>
+                    handleSelectorChange(option, 'indicator')}
+                  value={filtersSelected.indicator}
+                />
+              </div>
+            </div>
+            <Chart
+              className={styles.chartWrapper}
+              type="line"
+              config={config}
+              data={data}
+              dataOptions={filtersOptions.scenarios}
+              dataSelected={filtersSelected.scenario}
+              customMessage={this.renderCustomMessage()}
+              height={600}
+              loading={loading}
+              error={error}
+              margin={{ top: 50 }}
+              onLegendChange={handleLegendChange}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+EmissionPathways.propTypes = {
+  data: PropTypes.array,
+  config: PropTypes.object,
+  loading: PropTypes.bool,
+  error: PropTypes.bool,
+  filtersLoading: PropTypes.object,
+  filtersOptions: PropTypes.object,
+  filtersSelected: PropTypes.object,
+  handleSelectorChange: PropTypes.func.isRequired,
+  handleModelChange: PropTypes.func.isRequired,
+  handleLegendChange: PropTypes.func.isRequired
+};
+
+EmissionPathways.defaultProps = {
+  data: undefined,
+  config: undefined,
+  loading: false,
+  error: false,
+  filtersLoading: undefined,
+  filtersOptions: undefined,
+  filtersSelected: undefined
+};
+
+export default EmissionPathways;

--- a/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-reducers.js
+++ b/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-reducers.js
@@ -1,0 +1,34 @@
+import actions from './emission-pathways-actions';
+
+export const initialState = {
+  loading: false,
+  error: false,
+  loaded: false,
+  locations: {}
+};
+
+const setLoading = (loading, state) => ({ ...state, loading });
+const setLoaded = (loaded, state) => ({ ...state, loaded });
+const setError = (error, state) => ({ ...state, error });
+
+export default {
+  [actions.findAvailableModelsInit]: state => setLoading(true, state),
+  [actions.findAvailableModelsReady]: (state, { payload }) =>
+    setError(
+      false,
+      setLoaded(
+        true,
+        setLoading(false, {
+          ...state,
+          locations: {
+            ...state.locations,
+            [payload.locationId]: payload.modelIds
+          }
+        })
+      )
+    ),
+  [actions.findAvailableModelsFail]: state => {
+    setLoading(false, { ...state });
+    setError(true, { ...state });
+  }
+};

--- a/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-selectors.js
+++ b/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-selectors.js
@@ -1,0 +1,536 @@
+import { createSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+import isUndefined from 'lodash/isUndefined';
+import uniqBy from 'lodash/uniqBy';
+import uniq from 'lodash/uniq';
+import groupBy from 'lodash/groupBy';
+import isArray from 'lodash/isArray';
+import sortBy from 'lodash/sortBy';
+import remove from 'lodash/remove';
+import pick from 'lodash/pick';
+import {
+  getYColumnValue,
+  getThemeConfig,
+  getTooltipConfig,
+  setYAxisDomain
+} from 'utils/graphs';
+
+export const ESP_BLACKLIST = {
+  models: [
+    'id',
+    'scenario_ids',
+    'indicator_ids',
+    'availability',
+    'current_version',
+    'development_year',
+    'expertise',
+    'license'
+  ],
+  scenarios: [ 'id', 'model_id', 'indicator_ids' ],
+  indicators: [ 'id', 'parent_id' ]
+};
+
+const AXES_CONFIG = {
+  xBottom: { name: 'Year', unit: 'date', format: 'YYYY' },
+  yLeft: { name: 'Emissions', unit: 'CO<sub>2</sub>e', format: 'number' }
+};
+
+const DEFAULT_SELECTIONS = {
+  model: 'Global Change Assessment Model',
+  subcategory: {
+    best: 'GHG Emissions by gas with LULUCF',
+    secondBest: 'GHG emissions by gas without LULUCF',
+    thirdBest: 'Total GHG Emissions'
+  },
+  indicator: 'CO2'
+};
+
+// meta data for selectors
+const getLocations = state => state.locations || null;
+const getModels = state => state.models || null;
+const getAllScenarios = state => state.allScenarios || null;
+const getIndicators = state => state.indicators || null;
+
+const getModel = state => parseInt(state.model, 10) || null;
+const getScenarios = state => state.scenario || null;
+const getIndicator = state => parseInt(state.indicator, 10) || null;
+const getCategory = state => parseInt(state.category, 10) || null;
+const getSubcategory = state => parseInt(state.subcategory, 10) || null;
+
+// data for the graph
+const getData = state => state.data || null;
+
+// Selector options
+export const getLocationsOptions = createSelector(
+  [ getLocations ],
+  locations => {
+    if (!locations || !locations.length) return [];
+    return sortBy(locations, 'name').map(l => ({ label: l.name, value: l.id }));
+  }
+);
+
+const getLocationSelected = createSelector(
+  [ getLocationsOptions ],
+  locations => {
+    if (!locations || isEmpty(locations)) return null;
+    return locations.find(l => l.label === 'India');
+  }
+);
+
+const getAvailableModels = createSelector(
+  [ state => state.availableModels, getLocationSelected ],
+  (availableModels, location) => {
+    if (isEmpty(availableModels) || !location) return null;
+    return availableModels[location.value];
+  }
+);
+
+export const getModelsOptions = createSelector(
+  [ getModels, getAvailableModels ],
+  (models, availableModels) => {
+    if (
+      !models || !models.length || !availableModels || isEmpty(availableModels)
+    ) {
+      return null;
+    }
+    const modelOptions = [];
+    models.forEach(m => {
+      if (availableModels.indexOf(m.id) > -1) {
+        modelOptions.push({
+          label: m.full_name,
+          value: m.id,
+          scenarios: m.scenario_ids,
+          logo: m.logo,
+          url: m.url
+        });
+      }
+    });
+    return modelOptions;
+  }
+);
+
+export const getModelSelected = createSelector(
+  [ getModelsOptions, getModel, getModels ],
+  (models, modelSelected, allModels) => {
+    if (!models || isEmpty(allModels)) return null;
+    if (!modelSelected) {
+      const defaultModel = models.find(
+        m => m.label === DEFAULT_SELECTIONS.model
+      );
+      return defaultModel || models[0];
+    }
+    return models.find(m => modelSelected === m.value);
+  }
+);
+
+export const getUnavailableModelSelected = createSelector(
+  [ getModel, getModelSelected, getModels ],
+  (modelSelected, availableModel, allModels) => {
+    if (isEmpty(allModels) || !modelSelected) return null;
+    if (availableModel) return availableModel;
+    const unavailableModel = allModels.find(m => modelSelected === m.id);
+    return { label: unavailableModel.full_name };
+  }
+);
+
+export const getScenariosOptions = createSelector(
+  [ getAllScenarios, getModelSelected ],
+  (allScenarios, modelSelected) => {
+    if (!modelSelected || !allScenarios || !allScenarios.length) return null;
+    const filteredScenarios = allScenarios.filter(
+      s => modelSelected.scenarios.indexOf(s.id) > -1
+    );
+    return filteredScenarios.map(s => ({
+      label: s.name,
+      value: s.id,
+      purpose: s.purpose_or_objective || ''
+    }));
+  }
+);
+
+export const getScenariosSelected = createSelector(
+  [ getScenariosOptions, getScenarios, getModelSelected ],
+  (scenarios, scenariosSelected, model) => {
+    if (!scenarios || !model) return null;
+    if (!scenariosSelected && !model.scenarios || scenariosSelected === '') {
+      return null;
+    }
+    if (!scenariosSelected) {
+      return scenarios;
+    }
+    const scenarioSelectedArray = isArray(scenariosSelected)
+      ? scenariosSelected
+      : scenariosSelected.split(',');
+    const scenarioSelectedParsed = scenarioSelectedArray.map(
+      s => parseInt(s, 10)
+    );
+    return scenarios.filter(s => scenarioSelectedParsed.indexOf(s.value) > -1);
+  }
+);
+
+// Map the data from the API
+export const filterDataByScenario = createSelector(
+  [ getData, getScenariosSelected ],
+  (data, scenarios) => {
+    if (!data || isEmpty(data) || scenarios === '') return null;
+    if (!scenarios) return data;
+    return data.filter(
+      d => scenarios.map(s => s.value).indexOf(d.scenario_id) > -1
+    );
+  }
+);
+
+const getIndicatorsWithData = createSelector(
+  [ filterDataByScenario, getIndicators, getModelSelected ],
+  (data, indicators, modelSelected) => {
+    if (!data || !indicators || !indicators.length || !modelSelected) {
+      return null;
+    }
+    const indicatorsWithData = uniq(data.map(d => d.indicator_id));
+    return indicators.filter(
+      i => i.name && indicatorsWithData.indexOf(i.id) > -1
+    );
+  }
+);
+
+export const getCategoryOptions = createSelector(
+  [ getIndicatorsWithData ],
+  indicators => {
+    if (!indicators) return null;
+    const categories = indicators
+      .filter(i => i.category)
+      .map(i => ({ label: i.category.name, value: i.category.id }));
+    return uniqBy(categories, 'value');
+  }
+);
+
+export const getCategorySelected = createSelector(
+  [ getCategoryOptions, getCategory ],
+  (categories, categorySelected) => {
+    if (!categories) return null;
+    if (!categorySelected) {
+      return categories[0];
+    }
+    return categories.find(i => i.value === categorySelected);
+  }
+);
+
+export const getSubCategoryOptions = createSelector(
+  [ getIndicatorsWithData, getCategorySelected ],
+  (indicators, category) => {
+    if (!indicators || !category) return null;
+    const indicatorsSelected = indicators.filter(
+      i => i.category && i.category.id === category.value
+    );
+    const subcategories = (indicatorsSelected || []).map(i => ({
+      label: i.subcategory && i.subcategory.name,
+      value: i.subcategory && i.subcategory.id
+    }));
+    return uniqBy(subcategories, 'value');
+  }
+);
+
+export const getSubcategorySelected = createSelector(
+  [ getSubCategoryOptions, getSubcategory ],
+  (subcategories, subcategorySelected) => {
+    if (!subcategories) return null;
+    if (!subcategorySelected) {
+      const defaultSubcategory = subcategories.find(
+        s =>
+          s.label === DEFAULT_SELECTIONS.subcategory.best ||
+            s.label === DEFAULT_SELECTIONS.subcategory.secondBest ||
+            s.label === DEFAULT_SELECTIONS.subcategory.thirdBest
+      );
+      return defaultSubcategory || subcategories[0];
+    }
+    return subcategories.find(s => subcategorySelected === s.value);
+  }
+);
+
+export const getIndicatorsOptions = createSelector(
+  [ getIndicatorsWithData, getSubcategorySelected ],
+  (indicators, subcategory) => {
+    if (!indicators || !indicators.length || !subcategory) return [];
+    let filteredIndicators = indicators;
+    if (subcategory) {
+      filteredIndicators = indicators.filter(
+        i => i.subcategory && i.subcategory.id === subcategory.value
+      );
+    }
+
+    return filteredIndicators.map(i => ({
+      label: i.name || i.composite_name || '',
+      value: i.id,
+      unit: i.unit,
+      subcategory: i.subcategory.name
+    }));
+  }
+);
+
+export const getIndicatorSelected = createSelector(
+  [ getIndicatorsOptions, getIndicator ],
+  (indicators, indicatorSelected) => {
+    if (!indicators || !indicators.length) return null;
+    if (!indicatorSelected) {
+      const defaultIndicator = indicators.find(
+        i => i.label === DEFAULT_SELECTIONS.indicator
+      );
+      return defaultIndicator || indicators[0];
+    }
+    return indicators.find(i => indicatorSelected === i.value);
+  }
+);
+
+export const getUnavailableIndicatorSelected = createSelector(
+  [ getIndicator, getIndicatorSelected, getIndicators ],
+  (indicatorSelected, availableIndicator, allIndicators) => {
+    if (isEmpty(allIndicators)) return null;
+    if (!isUndefined(availableIndicator)) return availableIndicator;
+    const unavailableIndicator = allIndicators.find(
+      m => indicatorSelected === m.id
+    );
+    return { label: unavailableIndicator.name };
+  }
+);
+
+export const filterDataByIndicator = createSelector(
+  [ filterDataByScenario, getIndicatorSelected ],
+  (data, indicator) => {
+    if (!data || isEmpty(data) || !indicator) return null;
+    return data.filter(d => d.indicator_id === indicator.value);
+  }
+);
+
+export const getFiltersOptions = createSelector(
+  [
+    getLocationsOptions,
+    getModelsOptions,
+    getScenariosOptions,
+    getIndicatorsOptions,
+    getCategoryOptions,
+    getSubCategoryOptions
+  ],
+  (locations, models, scenarios, indicators, category, subcategory) => ({
+    locations,
+    models,
+    scenarios,
+    indicators,
+    category,
+    subcategory
+  })
+);
+
+export const getFiltersSelected = createSelector(
+  [
+    getLocationSelected,
+    getModelSelected,
+    getUnavailableModelSelected,
+    getScenariosSelected,
+    getCategorySelected,
+    getSubcategorySelected,
+    getIndicatorSelected,
+    getUnavailableIndicatorSelected
+  ],
+  (
+    location,
+    model,
+    unavailableModel,
+    scenario,
+    category,
+    subcategory,
+    indicator,
+    unavailableIndicator
+  ) => ({
+    location,
+    model: model || unavailableModel,
+    scenario,
+    category,
+    subcategory,
+    indicator: indicator || unavailableIndicator
+  })
+);
+
+export const getChartData = createSelector([ filterDataByIndicator ], data => {
+  if (!data) return null;
+  const groupByYear = groupBy(data, 'year');
+  const xValues = Object.keys(groupByYear);
+  const dataMapped = [];
+  xValues.forEach(x => {
+    const yValues = {};
+    const groupedByScenario = groupBy(groupByYear[x], 'scenario_id');
+    Object.keys(groupedByScenario).forEach(i => {
+      yValues[`y${i}`] = parseFloat(groupedByScenario[i][0].value);
+    });
+    dataMapped.push({ x: parseInt(x, 10), ...yValues });
+  });
+
+  return dataMapped;
+});
+
+export const getChartDomain = createSelector([ getChartData ], data => {
+  if (!data) return null;
+  const xValues = data.map(d => d.x);
+
+  return {
+    x: [ String(Math.min(...xValues)), String(Math.max(...xValues)) ],
+    y: setYAxisDomain()
+  };
+});
+
+export const getChartNeededPrecision = createSelector(
+  [ getChartDomain ],
+  domain => {
+    if (!domain) return null;
+    const yValuesDifference = domain.y[1] - domain.y[0];
+    const decimalZerosBeforeNumber = String(yValuesDifference).match(
+      /0\.(0+)[^0]/
+    );
+    const neededPrecision = decimalZerosBeforeNumber &&
+      decimalZerosBeforeNumber[1] &&
+      decimalZerosBeforeNumber.length;
+    return neededPrecision && neededPrecision + 1;
+  }
+);
+// The y axis domain has some margins added when the values are very similar to each other to represent this little difference
+export const getChartDomainWithYMargins = createSelector(
+  [ getChartDomain, getChartNeededPrecision ],
+  (domain, neededPrecision) => {
+    if (!domain) return null;
+    if (!neededPrecision) return domain;
+    const y = [
+      dataMin => dataMin - 10 ** ((neededPrecision - 1) * (-1)),
+      dataMax => dataMax + 10 ** ((neededPrecision - 1) * (-1))
+    ];
+    return { x: domain.x, y };
+  }
+);
+
+// variable that caches chart elements assigned color
+// to avoid element color changing when the chart is updated
+let colorThemeCache = {};
+
+export const getChartConfig = createSelector(
+  [
+    filterDataByIndicator,
+    getAllScenarios,
+    getScenariosOptions,
+    getIndicatorSelected,
+    getChartNeededPrecision
+  ],
+  (data, allScenarios, scenariosInChart, indicator, precision) => {
+    if (!data || !allScenarios) return null;
+    const yColumns = data.map(d => {
+      const scenario = scenariosInChart &&
+        scenariosInChart.find(s => parseInt(s.value, 10) === d.scenario_id);
+      return {
+        label: scenario ? scenario.label : null,
+        value: getYColumnValue(d.scenario_id),
+        legendTooltip: scenario && scenario.purpose
+      };
+    });
+
+    const yColumnsChecked = uniqBy(yColumns, 'value');
+    const theme = getThemeConfig(yColumnsChecked, colorThemeCache);
+    colorThemeCache = { ...theme, ...colorThemeCache };
+    const tooltip = getTooltipConfig(yColumnsChecked);
+    const axes = indicator
+      ? {
+        ...AXES_CONFIG,
+        yLeft: { ...AXES_CONFIG.yLeft, unit: indicator.unit }
+      }
+      : AXES_CONFIG;
+    return {
+      axes,
+      theme: colorThemeCache,
+      tooltip,
+      precision,
+      columns: { x: [ { label: 'year', value: 'x' } ], y: yColumnsChecked }
+    };
+  }
+);
+
+// Parse Metadata for Modal
+const getModelSelectedMetadata = createSelector(
+  [ getModels, getModelSelected ],
+  (models, modelSelected) => {
+    if (!models || !modelSelected) return null;
+    return models.find(m => modelSelected.value === m.id);
+  }
+);
+
+const addLinktoModelSelectedMetadata = createSelector(
+  [ getModelSelectedMetadata ],
+  model => {
+    if (!model) return null;
+    return { ...model, Link: `/pathways/models/${model.id}` };
+  }
+);
+
+export const getScenariosSelectedMetadata = createSelector(
+  [ getAllScenarios, getScenariosSelected ],
+  (allScenarios, scenariosSelected) => {
+    if (isEmpty(allScenarios) || !scenariosSelected) return null;
+    const selectedScenarioIds = scenariosSelected.map(s => s.value);
+    const scenariosMetadata = allScenarios.filter(
+      s => selectedScenarioIds.indexOf(s.id) > -1
+    );
+    return scenariosMetadata.length > 0 &&
+      scenariosMetadata.map(s => ({
+        name: s.name,
+        description: s.description,
+        Link: `/pathways/scenarios/${s.id}`
+      }));
+  }
+);
+
+export const getIndicatorSelectedMetadata = createSelector(
+  [ getIndicators, getIndicatorSelected ],
+  (indicators, indicatorSelected) => {
+    if (!indicators || !indicatorSelected) return null;
+    return indicators.find(i => indicatorSelected.value === i.id);
+  }
+);
+
+export const filterModelsByBlackList = createSelector(
+  [ addLinktoModelSelectedMetadata ],
+  data => {
+    if (!data || isEmpty(data)) return null;
+    const whiteList = remove(
+      Object.keys(data),
+      n => ESP_BLACKLIST.models.indexOf(n) === -1
+    );
+    return pick(data, whiteList);
+  }
+);
+
+const filterIndicatorsByBlackList = createSelector(
+  [ getIndicatorSelectedMetadata ],
+  data => {
+    if (!data || isEmpty(data)) return null;
+    const whiteList = remove(
+      Object.keys(data),
+      n => ESP_BLACKLIST.indicators.indexOf(n) === -1
+    );
+    return pick(data, whiteList);
+  }
+);
+
+export const parseObjectsInIndicators = createSelector(
+  [ filterIndicatorsByBlackList ],
+  data => {
+    if (isEmpty(data)) return null;
+    const parsedData = {};
+    Object.keys(data).forEach(key => {
+      let fieldData = data[key];
+      if (
+        fieldData &&
+          typeof fieldData !== 'string' &&
+          typeof fieldData !== 'number'
+      ) {
+        fieldData = fieldData.name;
+      }
+      parsedData[key] = fieldData;
+    });
+    return parsedData;
+  }
+);

--- a/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-styles.scss
+++ b/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-styles.scss
@@ -1,0 +1,87 @@
+@import '~styles/settings.scss';
+@import '~styles/layout.scss';
+
+.page {
+  @include row();
+
+  margin-top: $gutter-padding;
+}
+
+$min-height: 450px;
+
+.wrapper {
+  border-bottom: solid 1px $border-color;
+  min-height: 450px;
+  padding-bottom: 50px;
+}
+
+.titleAndBtnsWrapper {
+  @include columns(6);
+
+  > * {
+    @include xy-gutters($gutter-position: ('bottom'));
+  }
+
+  @media #{$tablet-landscape} {
+    > *:last-child {
+      @include column-offset(7.2, $gutters: true);
+    }
+
+    @include columns(2.4);
+  }
+}
+
+.selectorsWrapper {
+  @include columns(6);
+
+  > * {
+    @include xy-gutters($gutter-position: ('bottom'));
+  }
+
+  @media #{$tablet-landscape} {
+    @include columns(2.4);
+  }
+}
+
+.titleAndBtnsWrapper {
+  @include xy-gutters($gutter-position: ('bottom'));
+
+  margin-top: $gutter-padding;
+}
+
+.selectorsWrapper {
+  margin-bottom: 40px;
+}
+
+.title {
+  font-size: $font-size-large;
+  font-weight: $font-weight;
+  color: $theme-color;
+  margin-bottom: 10px;
+}
+
+.chartWrapper {
+  position: relative;
+  min-height: $min-height;
+}
+
+.loader {
+  min-height: 450px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+}
+
+.noContent {
+  min-height: $min-height;
+}
+
+.clearButton {
+  color: $theme-color;
+  border-bottom: 1px solid $action-color;
+  vertical-align: bottom;
+  font-size: 1em;
+  cursor: pointer;
+}
+

--- a/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-styles.scss
+++ b/app/javascript/app/pages/country-context/emission-pathways/emission-pathways-styles.scss
@@ -85,3 +85,7 @@ $min-height: 450px;
   cursor: pointer;
 }
 
+.buttonWrapper {
+  align-self: flex-end;
+  max-width: 100px;
+}

--- a/app/javascript/app/pages/country-context/emission-pathways/emission-pathways.js
+++ b/app/javascript/app/pages/country-context/emission-pathways/emission-pathways.js
@@ -1,0 +1,203 @@
+import { PureComponent, createElement } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import qs from 'query-string';
+import isArray from 'lodash/isArray';
+
+import actions from './emission-pathways-actions';
+import reducers, { initialState } from './emission-pathways-reducers';
+
+import EmissionPathwayGraphComponent from './emission-pathways-component';
+import {
+  getChartData,
+  getChartDomainWithYMargins,
+  getChartConfig,
+  getFiltersOptions,
+  getFiltersSelected,
+  getModelSelected
+} from './emission-pathways-selectors';
+
+const mapStateToProps = state => {
+  const { data } = state.espTimeSeries;
+  const search = qs.parse(state.location.search);
+  const {
+    currentLocation,
+    model,
+    indicator,
+    scenario,
+    category,
+    subcategory
+  } = search;
+  const espData = {
+    data,
+    locations: state.espLocations.data,
+    models: state.espModels.data,
+    allScenarios: state.espScenarios.data,
+    indicators: state.espIndicators.data,
+    location: currentLocation,
+    availableModels: state.espGraph.locations,
+    model,
+    indicator,
+    scenario,
+    category,
+    subcategory,
+    search
+  };
+  const providers = [
+    'espTimeSeries',
+    'espLocations',
+    'espModels',
+    'espScenarios',
+    'espIndicators',
+    'espGraph'
+  ];
+  const filtersSelected = getFiltersSelected(espData);
+  return {
+    data: getChartData(espData),
+    domain: getChartDomainWithYMargins(espData),
+    config: getChartConfig(espData),
+    filtersLoading: {
+      timeseries: state.espTimeSeries.loading,
+      locations: state.espLocations.loading,
+      models: state.espModels.loading,
+      indicators: state.espIndicators.loading
+    },
+    filtersOptions: getFiltersOptions(espData),
+    filtersSelected,
+    model: getModelSelected(espData),
+    error: providers.some(p => state[p].error),
+    loading: providers.some(p => state[p].loading) || !filtersSelected.model,
+    search,
+    location: state.location
+  };
+};
+
+class EmissionPathwaysContainer extends PureComponent {
+  componentDidMount() {
+    const { filtersSelected, findAvailableModels } = this.props;
+    const { location } = filtersSelected;
+    if (location) {
+      const locationId = location.value || location;
+      findAvailableModels(locationId);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { filtersSelected, findAvailableModels, search } = this.props;
+    if (prevProps.filtersSelected.location !== filtersSelected.location) {
+      const currentLocation = filtersSelected.location;
+      findAvailableModels(currentLocation.value);
+    }
+
+    this.updateUrlWithNewParams(search, filtersSelected);
+  }
+
+  getLocationParamUpdated(params = [], clear = false) {
+    const { updateFiltersSelected } = this.props;
+
+    const { search } = this.props;
+    const newFilters = {};
+    const paramsArray = isArray(params) ? params : [ params ];
+    paramsArray.forEach(param => {
+      newFilters[param.name] = param.value;
+    });
+    const newSearch = clear ? { ...newFilters } : { ...search, ...newFilters };
+
+    updateFiltersSelected({ section: 'emission-pathways', query: newSearch });
+  }
+
+  updateUrlWithNewParams = (search, filtersSelected) => {
+    const possibleParams = [
+      'model',
+      'category',
+      'subcategory',
+      'indicator',
+      'currentLocation',
+      'scenario'
+    ];
+    const paramsToUpdate = [];
+    const getFilterParamValue = f => {
+      if (isArray(filtersSelected[f])) {
+        return search[f]
+          ? filtersSelected[f]
+            .filter(selectedFilter => search[f].includes(selectedFilter.value))
+            .join(',')
+          : filtersSelected[f].map(filter => filter.value).join(',');
+      }
+      return filtersSelected[f].value;
+    };
+
+    possibleParams.forEach(f => {
+      if (!search[f]) {
+        if (f === 'currentLocation' && filtersSelected.location) {
+          paramsToUpdate.push({
+            name: f,
+            value: filtersSelected[f] && filtersSelected[f].value ||
+              filtersSelected.location.value
+          });
+        } else if (f !== 'currentLocation' && filtersSelected[f]) {
+          const value = getFilterParamValue(f);
+          if (value) paramsToUpdate.push({ name: f, value });
+        }
+      }
+    });
+    if (paramsToUpdate.length) this.getLocationParamUpdated(paramsToUpdate);
+  };
+
+  handleModelChange = model => {
+    const { filtersSelected } = this.props;
+    const { location } = filtersSelected;
+    const params = [
+      { name: 'model', value: model.value },
+      {
+        name: 'scenario',
+        value: model.scenarios ? model.scenarios.toString() : ''
+      }
+    ];
+    if (location && location.value) {
+      params.push({ name: 'currentLocation', value: location.value });
+    }
+    this.getLocationParamUpdated(params, true);
+  };
+
+  handleSelectorChange = (option, param, clear) => {
+    const params = [ { name: param, value: option ? option.value : '' } ];
+    if (param === 'category') {
+      params.push({ name: 'subcategory', value: '' });
+    }
+    if (param === 'category' || param === 'subcategory') {
+      params.push({ name: 'indicator', value: '' });
+    }
+    this.getLocationParamUpdated(params, clear);
+  };
+
+  handleLegendChange = value => {
+    this.handleSelectorChange(
+      { value: value.map(v => v.value).join() },
+      'scenario'
+    );
+  };
+
+  render() {
+    return createElement(EmissionPathwayGraphComponent, {
+      ...this.props,
+      handleModelChange: this.handleModelChange,
+      handleSelectorChange: this.handleSelectorChange,
+      handleClearSelection: this.handleClearSelection,
+      handleLegendChange: this.handleLegendChange
+    });
+  }
+}
+
+EmissionPathwaysContainer.propTypes = {
+  updateFiltersSelected: PropTypes.func.isRequired,
+  filtersSelected: PropTypes.object.isRequired,
+  findAvailableModels: PropTypes.func.isRequired,
+  search: PropTypes.object,
+  location: PropTypes.object
+};
+
+EmissionPathwaysContainer.defaultProps = { search: {}, location: {} };
+
+export const reduxModule = { actions, reducers, initialState };
+export default connect(mapStateToProps, actions)(EmissionPathwaysContainer);

--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/socioeconomic-indicators-component.jsx
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/socioeconomic-indicators-component.jsx
@@ -5,6 +5,7 @@ import Population from './population';
 import Economy from './economy';
 import Energy from './energy';
 
+// eslint-disable-next-line react/prefer-stateless-function
 class SocioeconomicIndicators extends PureComponent {
   render() {
     return (

--- a/app/javascript/app/providers/esp-indicators-provider/esp-indicators-provider-actions.js
+++ b/app/javascript/app/providers/esp-indicators-provider/esp-indicators-provider-actions.js
@@ -1,0 +1,44 @@
+import { createAction, createThunkAction } from 'redux-tools';
+import upperFirst from 'lodash/upperFirst';
+import isEmpty from 'lodash/isEmpty';
+import { ESPAPI } from 'services/api';
+
+const fetchEspIndicatorsInit = createAction('fetchEspIndicatorsInit');
+const fetchEspIndicatorsReady = createAction('fetchEspIndicatorsReady');
+const fetchEspIndicatorsFail = createAction('fetchEspIndicatorsFail');
+
+const fetchEspIndicators = createThunkAction('fetchEspIndicators', () =>
+  (dispatch, state) => {
+    const { espIndicators } = state();
+    if (
+      espIndicators.data &&
+        isEmpty(espIndicators.data) &&
+        !espIndicators.loading
+    ) {
+      dispatch(fetchEspIndicatorsInit());
+      ESPAPI
+        .get('indicators')
+        .then(data => {
+          if (data) {
+            const dataParsed = data.map(d => ({
+              ...d,
+              name: upperFirst(d.name)
+            }));
+            dispatch(fetchEspIndicatorsReady(dataParsed));
+          } else {
+            dispatch(fetchEspIndicatorsReady({}));
+          }
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(fetchEspIndicatorsFail());
+        });
+    }
+  });
+
+export default {
+  fetchEspIndicators,
+  fetchEspIndicatorsInit,
+  fetchEspIndicatorsReady,
+  fetchEspIndicatorsFail
+};

--- a/app/javascript/app/providers/esp-indicators-provider/esp-indicators-provider-reducers.js
+++ b/app/javascript/app/providers/esp-indicators-provider/esp-indicators-provider-reducers.js
@@ -1,0 +1,24 @@
+import actions from './esp-indicators-provider-actions';
+
+export const initialState = {
+  loading: false,
+  error: false,
+  loaded: false,
+  data: {}
+};
+
+const setLoading = (loading, state) => ({ ...state, loading });
+const setLoaded = (loaded, state) => ({ ...state, loaded });
+const setError = (error, state) => ({ ...state, error });
+
+export default {
+  [actions.fetchEspIndicatorsInit]: state => setLoading(true, state),
+  [actions.fetchEspIndicatorsReady]: (state, { payload }) =>
+    setError(
+      false,
+      setLoaded(true, setLoading(false, { ...state, data: payload }))
+    ),
+  [actions.fetchEspIndicatorsFail]: state => {
+    setError(true, setLoading(false, setLoaded(true, { ...state })));
+  }
+};

--- a/app/javascript/app/providers/esp-indicators-provider/esp-indicators-provider.js
+++ b/app/javascript/app/providers/esp-indicators-provider/esp-indicators-provider.js
@@ -1,0 +1,24 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import actions from './esp-indicators-provider-actions';
+import reducers, { initialState } from './esp-indicators-provider-reducers';
+
+class EspIndicatorsProvider extends PureComponent {
+  componentDidMount() {
+    const { fetchEspIndicators } = this.props;
+    fetchEspIndicators();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+EspIndicatorsProvider.propTypes = {
+  fetchEspIndicators: PropTypes.func.isRequired
+};
+
+export const reduxModule = { actions, reducers, initialState };
+export default connect(null, actions)(EspIndicatorsProvider);

--- a/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-actions.js
+++ b/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-actions.js
@@ -1,0 +1,57 @@
+import { createAction, createThunkAction } from 'redux-tools';
+import isEmpty from 'lodash/isEmpty';
+import { ESPAPI } from 'services/api';
+
+const getEspLocationsInit = createAction('getEspLocationsInit');
+const getEspLocationsReady = createAction('getEspLocationsReady');
+const getEspLocationsWithScenarioReady = createAction(
+  'getEspLocationsWithScenarioReady'
+);
+const getEspLocationsFail = createAction('getEspLocationsFail');
+
+const getEspLocations = createThunkAction('getEspLocations', (
+  { withTimeSeries, scenarioId }
+) =>
+  (dispatch, state) => {
+    const { espLocations } = state();
+    if (
+      espLocations.data &&
+        isEmpty(espLocations.data) &&
+        !espLocations.loading ||
+        scenarioId &&
+          espLocations.scenarios &&
+          !espLocations.scenarios[scenarioId] ||
+        espLocations.error
+    ) {
+      dispatch(getEspLocationsInit());
+      const scenarioParam = scenarioId ? { scenario: scenarioId } : {};
+      const withTimeSeriesParam = withTimeSeries && !scenarioId
+        ? { time_series: true }
+        : {};
+      ESPAPI
+        .get('locations', { ...withTimeSeriesParam, ...scenarioParam })
+        .then(data => {
+          if (data) {
+            if (scenarioId) {
+              dispatch(getEspLocationsWithScenarioReady({ data, scenarioId }));
+            } else {
+              dispatch(getEspLocationsReady(data));
+            }
+          } else {
+            dispatch(getEspLocationsReady({}));
+          }
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(getEspLocationsFail());
+        });
+    }
+  });
+
+export default {
+  getEspLocations,
+  getEspLocationsInit,
+  getEspLocationsReady,
+  getEspLocationsWithScenarioReady,
+  getEspLocationsFail
+};

--- a/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-reducers.js
+++ b/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-reducers.js
@@ -1,0 +1,35 @@
+import actions from './esp-locations-provider-actions';
+
+export const initialState = {
+  loading: false,
+  error: false,
+  loaded: false,
+  data: {},
+  scenarios: {}
+};
+
+const setLoading = (loading, state) => ({ ...state, loading });
+const setLoaded = (loaded, state) => ({ ...state, loaded });
+const setError = (error, state) => ({ ...state, error });
+
+export default {
+  [actions.getEspLocationsInit]: state => setLoading(true, state),
+  [actions.getEspLocationsReady]: (state, { payload }) =>
+    setError(
+      false,
+      setLoaded(true, setLoading(false, { ...state, data: payload }))
+    ),
+  [actions.getEspLocationsWithScenarioReady]: (state, { payload }) =>
+    setError(
+      false,
+      setLoaded(
+        true,
+        setLoading(false, {
+          ...state,
+          scenarios: { ...state.scenarios, [payload.scenarioId]: payload.data }
+        })
+      )
+    ),
+  [actions.getEspLocationsFail]: state =>
+    setError(true, setLoading(false, setLoaded(true, { ...state })))
+};

--- a/app/javascript/app/providers/esp-locations-provider/esp-locations-provider.js
+++ b/app/javascript/app/providers/esp-locations-provider/esp-locations-provider.js
@@ -1,0 +1,43 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import actions from './esp-locations-provider-actions';
+import reducers, { initialState } from './esp-locations-provider-reducers';
+
+class EspLocationsProvider extends PureComponent {
+  componentDidMount() {
+    const { withTimeSeries, scenarioId, getEspLocations } = this.props;
+    getEspLocations({ withTimeSeries, scenarioId });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {
+      withTimeSeries,
+      scenarioId: nextScenarioId,
+      getEspLocations
+    } = nextProps;
+    const { scenarioId } = this.props;
+    if (nextScenarioId !== scenarioId) {
+      getEspLocations({ withTimeSeries, scenarioId });
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+EspLocationsProvider.propTypes = {
+  getEspLocations: PropTypes.func.isRequired,
+  withTimeSeries: PropTypes.bool,
+  scenarioId: PropTypes.string
+};
+
+EspLocationsProvider.defaultProps = {
+  withTimeSeries: true,
+  scenarioId: undefined
+};
+
+export const reduxModule = { actions, reducers, initialState };
+export default connect(null, actions)(EspLocationsProvider);

--- a/app/javascript/app/providers/esp-models-provider/esp-models-provider-actions.js
+++ b/app/javascript/app/providers/esp-models-provider/esp-models-provider-actions.js
@@ -1,0 +1,35 @@
+import { createAction, createThunkAction } from 'redux-tools';
+import isEmpty from 'lodash/isEmpty';
+import { ESPAPI } from 'services/api';
+
+const fetchEspModelsInit = createAction('fetchEspModelsInit');
+const fetchEspModelsReady = createAction('fetchEspModelsReady');
+const fetchEspModelsFail = createAction('fetchEspModelsFail');
+
+const fetchEspModels = createThunkAction('fetchEspModels', () =>
+  (dispatch, state) => {
+    const { espModels } = state();
+    if (espModels.data && isEmpty(espModels.data) && !espModels.loading) {
+      dispatch(fetchEspModelsInit());
+      ESPAPI
+        .get('models')
+        .then(data => {
+          if (data) {
+            dispatch(fetchEspModelsReady(data));
+          } else {
+            dispatch(fetchEspModelsReady({}));
+          }
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(fetchEspModelsFail());
+        });
+    }
+  });
+
+export default {
+  fetchEspModels,
+  fetchEspModelsInit,
+  fetchEspModelsReady,
+  fetchEspModelsFail
+};

--- a/app/javascript/app/providers/esp-models-provider/esp-models-provider-reducers.js
+++ b/app/javascript/app/providers/esp-models-provider/esp-models-provider-reducers.js
@@ -1,0 +1,23 @@
+import actions from './esp-models-provider-actions';
+
+export const initialState = {
+  loading: false,
+  loaded: false,
+  error: false,
+  data: {}
+};
+
+const setError = (error, state) => ({ ...state, error });
+const setLoading = (loading, state) => ({ ...state, loading });
+const setLoaded = (loaded, state) => ({ ...state, loaded });
+
+export default {
+  [actions.fetchEspModelsInit]: state => setLoading(true, state),
+  [actions.fetchEspModelsReady]: (state, { payload }) =>
+    setError(
+      false,
+      setLoaded(true, setLoading(false, { ...state, data: payload }))
+    ),
+  [actions.fetchEspModelsFail]: state =>
+    setError(true, setLoading(false, setLoaded(true, { ...state })))
+};

--- a/app/javascript/app/providers/esp-models-provider/esp-models-provider.js
+++ b/app/javascript/app/providers/esp-models-provider/esp-models-provider.js
@@ -1,0 +1,22 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import actions from './esp-models-provider-actions';
+import reducers, { initialState } from './esp-models-provider-reducers';
+
+class EspModelsProvider extends PureComponent {
+  componentDidMount() {
+    const { fetchEspModels } = this.props;
+    fetchEspModels();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+EspModelsProvider.propTypes = { fetchEspModels: PropTypes.func.isRequired };
+
+export const reduxModule = { actions, reducers, initialState };
+export default connect(null, actions)(EspModelsProvider);

--- a/app/javascript/app/providers/esp-scenarios-provider/esp-scenarios-provider-actions.js
+++ b/app/javascript/app/providers/esp-scenarios-provider/esp-scenarios-provider-actions.js
@@ -1,0 +1,37 @@
+import { createAction, createThunkAction } from 'redux-tools';
+import isEmpty from 'lodash/isEmpty';
+import { ESPAPI } from 'services/api';
+
+export const fetchEspScenariosInit = createAction('fetchEspScenariosInit');
+export const fetchEspScenariosReady = createAction('fetchEspScenariosReady');
+export const fetchEspScenariosFail = createAction('fetchEspScenariosFail');
+
+export const fetchEspScenarios = createThunkAction('fetchEspScenarios', () =>
+  (dispatch, state) => {
+    const { espScenarios } = state();
+    if (
+      espScenarios.data && isEmpty(espScenarios.data) && !espScenarios.loading
+    ) {
+      dispatch(fetchEspScenariosInit());
+      ESPAPI
+        .get('scenarios')
+        .then(data => {
+          if (data) {
+            dispatch(fetchEspScenariosReady(data));
+          } else {
+            dispatch(fetchEspScenariosReady({}));
+          }
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(fetchEspScenariosFail());
+        });
+    }
+  });
+
+export default {
+  fetchEspScenarios,
+  fetchEspScenariosInit,
+  fetchEspScenariosReady,
+  fetchEspScenariosFail
+};

--- a/app/javascript/app/providers/esp-scenarios-provider/esp-scenarios-provider-reducers.js
+++ b/app/javascript/app/providers/esp-scenarios-provider/esp-scenarios-provider-reducers.js
@@ -1,0 +1,23 @@
+import * as actions from './esp-scenarios-provider-actions';
+
+export const initialState = {
+  loading: false,
+  error: false,
+  loaded: false,
+  data: {}
+};
+
+const setLoading = (loading, state) => ({ ...state, loading });
+const setLoaded = (loaded, state) => ({ ...state, loaded });
+const setError = (error, state) => ({ ...state, error });
+
+export default {
+  [actions.fetchEspScenariosInit]: state => setLoading(true, state),
+  [actions.fetchEspScenariosReady]: (state, { payload }) =>
+    setError(
+      false,
+      setLoaded(true, setLoading(false, { ...state, data: payload }))
+    ),
+  [actions.fetchEspScenariosFail]: state =>
+    setError(true, setLoading(false, setLoaded(true, { ...state })))
+};

--- a/app/javascript/app/providers/esp-scenarios-provider/esp-scenarios-provider.js
+++ b/app/javascript/app/providers/esp-scenarios-provider/esp-scenarios-provider.js
@@ -1,0 +1,24 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import actions from './esp-scenarios-provider-actions';
+import reducers, { initialState } from './esp-scenarios-provider-reducers';
+
+class EspScenariosProvider extends PureComponent {
+  componentDidMount() {
+    const { fetchEspScenarios } = this.props;
+    fetchEspScenarios();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+EspScenariosProvider.propTypes = {
+  fetchEspScenarios: PropTypes.func.isRequired
+};
+
+export const reduxModule = { actions, reducers, initialState };
+export default connect(null, actions)(EspScenariosProvider);

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
@@ -1,0 +1,33 @@
+import { createAction, createThunkAction } from 'redux-tools';
+import { ESPAPI } from 'services/api';
+
+const getEspTimeSeriesInit = createAction('getEspTimeSeriesInit');
+const getEspLocationsFail = createAction('getEspLocationsFail');
+const getEspTimeSeriesReady = createAction('getEspTimeSeriesReady');
+
+const getEspTimeSeries = createThunkAction('getEspTimeSeries', (
+  { location, model }
+) =>
+  (dispatch, state) => {
+    const { espTimeSeries } = state();
+    if (espTimeSeries && !espTimeSeries.loading) {
+      dispatch(getEspTimeSeriesInit());
+      const query = { location, model };
+
+      ESPAPI
+        .get('time_series_values', query)
+        .then(data => {
+          dispatch(getEspTimeSeriesReady(data));
+        })
+        .catch(error => {
+          console.info(error);
+          dispatch(getEspLocationsFail());
+        });
+    }
+  });
+
+export default {
+  getEspTimeSeries,
+  getEspTimeSeriesInit,
+  getEspTimeSeriesReady
+};

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-reducers.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-reducers.js
@@ -1,0 +1,23 @@
+import actions from './esp-time-series-provider-actions';
+
+export const initialState = {
+  error: false,
+  loaded: false,
+  loading: false,
+  data: {}
+};
+
+const setLoading = (loading, state) => ({ ...state, loading });
+const setLoaded = (loaded, state) => ({ ...state, loaded });
+const setError = (error, state) => ({ ...state, error });
+
+export default {
+  [actions.getEspTimeSeriesInit]: state => setLoading(true, state),
+  [actions.getEspTimeSeriesReady]: (state, { payload }) =>
+    setError(
+      false,
+      setLoaded(true, setLoading(false, { ...state, data: payload }))
+    ),
+  [actions.getEspTimeSeriesFail]: state =>
+    setError(true, setLoading(false, setLoaded(true, { ...state })))
+};

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider.js
@@ -1,0 +1,40 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import actions from './esp-time-series-provider-actions';
+import reducers, { initialState } from './esp-time-series-provider-reducers';
+
+class EspTimeSeriesProvider extends PureComponent {
+  componentDidMount() {
+    const { location, model, getEspTimeSeries } = this.props;
+    getEspTimeSeries({ location, model });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { location, model } = this.props;
+    if (nextProps.location !== location || nextProps.model !== model) {
+      const {
+        location: nextLocation,
+        model: nextModel,
+        getEspTimeSeries
+      } = nextProps;
+      getEspTimeSeries({ location: nextLocation, model: nextModel });
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+EspTimeSeriesProvider.propTypes = {
+  getEspTimeSeries: PropTypes.func.isRequired,
+  location: PropTypes.number.isRequired,
+  model: PropTypes.number
+};
+
+EspTimeSeriesProvider.defaultProps = { model: undefined };
+
+export const reduxModule = { actions, reducers, initialState };
+export default connect(null, actions)(EspTimeSeriesProvider);

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -17,11 +17,32 @@ import {
   reduxModule as ndcCountryAccordion
 } from 'components/ndcs-country-accordion';
 
+// Emission Pathways
+import {
+  reduxModule as espLocationsProvider
+} from 'providers/esp-locations-provider';
+import {
+  reduxModule as espTimeSeriesProvider
+} from 'providers/esp-time-series-provider';
+import {
+  reduxModule as espModelsProvider
+} from 'providers/esp-models-provider';
+import {
+  reduxModule as espScenariosProvider
+} from 'providers/esp-scenarios-provider';
+import {
+  reduxModule as espIndicatorsProvider
+} from 'providers/esp-indicators-provider';
+import {
+  reduxModule as espGraphComponent
+} from 'pages/country-context/emission-pathways/emission-pathways';
+
 // Router
 import router from './router';
 
 const componentsReducers = {
-  ndcCountryAccordion: handleModule(ndcCountryAccordion)
+  ndcCountryAccordion: handleModule(ndcCountryAccordion),
+  espGraph: handleModule(espGraphComponent)
 };
 
 const providersReducers = {
@@ -29,7 +50,12 @@ const providersReducers = {
   ClimatePoliciesDetails: handleModule(climatePoliciesDetails),
   modalMetadata: handleModule(modalMetadata),
   ndcContentOverview: handleModule(ndcContentOverview),
-  indicators: handleModule(indicators)
+  indicators: handleModule(indicators),
+  espModels: handleModule(espModelsProvider),
+  espScenarios: handleModule(espScenariosProvider),
+  espIndicators: handleModule(espIndicatorsProvider),
+  espLocations: handleModule(espLocationsProvider),
+  espTimeSeries: handleModule(espTimeSeriesProvider)
 };
 
 export default combineReducers({

--- a/app/javascript/app/router/sections/country-context.js
+++ b/app/javascript/app/router/sections/country-context.js
@@ -3,6 +3,12 @@ export default [
     slug: 'socioeconomic-indicators',
     label: 'Socioeconomic indicators',
     path: '/country-context',
-    default: true
+    default: true,
+    exact: true
+  },
+  {
+    slug: 'emission-pathways',
+    label: 'Emission pathways',
+    path: '/country-context/emission-pathways'
   }
 ];

--- a/app/javascript/app/services/api.js
+++ b/app/javascript/app/services/api.js
@@ -3,6 +3,7 @@ import qs from 'query-string';
 
 const { API_URL } = process.env;
 const { CW_API_URL } = process.env;
+const { ESP_API_URL } = process.env;
 
 function handleResponse(d) {
   if (d.status >= 200 && d.status <= 300) {
@@ -54,3 +55,4 @@ class API {
 
 export const CWAPI = new API(CW_API_URL);
 export const INDIAAPI = new API(API_URL);
+export const ESPAPI = new API(ESP_API_URL);

--- a/app/javascript/app/utils/graphs.js
+++ b/app/javascript/app/utils/graphs.js
@@ -1,5 +1,7 @@
 import isEmpty from 'lodash/isEmpty';
 import uniq from 'lodash/uniq';
+import upperFirst from 'lodash/upperFirst';
+import camelCase from 'lodash/camelCase';
 
 export const CHART_COLORS = [
   '#00B4D2',
@@ -65,3 +67,15 @@ export const getThemeConfig = (
     });
     return { ...theme, ...colorCache };
   };
+
+export const getColumnValue = column => upperFirst(camelCase(column));
+export const getYColumnValue = column => `y${getColumnValue(column)}`;
+
+function setBuffer(min) {
+  if (min <= 0.1) return min;
+  return min * 0.7;
+}
+
+export function setYAxisDomain() {
+  return [ setBuffer, 'auto' ];
+}


### PR DESCRIPTION
This PR copies the Emission Pathways page from CW with the same providers and uses it with cw-components and only for India. The links to the scenarios in the legend have been removed only the tooltip is shown.

Add to env:
`ESP_API_URL=https://data.emissionspathways.org/api/v1`

Extra: 

-Fix button position in responsive

![image](https://user-images.githubusercontent.com/9701591/51536011-76bcab00-1e4a-11e9-91e9-fda81befbdba.png)
