### PR TITLE
Fix/climate policy sources

### DIFF
--- a/app/controllers/api/v1/climate_policy/policies_controller.rb
+++ b/app/controllers/api/v1/climate_policy/policies_controller.rb
@@ -8,10 +8,17 @@ module Api
         end
 
         def show
-          policy = ::ClimatePolicy::Policy.find_by!(code: params[:code])
+          policy = ::ClimatePolicy::Policy.
+            includes(
+              instruments: [:sources],
+              indicators: [:sources],
+              milestones: [:source]
+            ).
+            find_by!(code: params[:code])
 
           render json: policy,
-                 serializer: Api::V1::ClimatePolicy::PolicyFullSerializer
+                 serializer: Api::V1::ClimatePolicy::PolicyFullSerializer,
+                 include: '**' # well this is weird but to get more than two levels...
         end
       end
     end

--- a/app/javascript/app/pages/climate-policies/indicators/indicators-component.jsx
+++ b/app/javascript/app/pages/climate-policies/indicators/indicators-component.jsx
@@ -13,20 +13,40 @@ const columnNames = {
   attainment_date: 'Date of attainment:',
   value: 'Indicator value:',
   responsible_authority: 'Responsible authority:',
-  data_source_link: 'Data source:',
   tracking_frequency: 'Tracking frequency:',
   tracking_notes: 'Notes on tracking methods:',
   status: 'Status:',
   sources: 'Sources:'
 };
 
-const isLink = columnName => columnName === 'data_source_link';
+const columnValueRenderers = {
+  sources: sources => sources.map(source => (
+    <div key={source.code}>
+      <a
+        href={source.link}
+        alt={source.code}
+        className={styles.link}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {source.code}
+      </a>
+    </div>
+  ))
+};
+const columnValueDefaultRenderer = value => <ReactMarkdown source={value} />;
+
+const renderColumnValue = (indicator, column) => {
+  const value = indicator[column];
+  if (!value) return null;
+  const renderer = columnValueRenderers[column];
+  if (renderer) return renderer(value);
+  return columnValueDefaultRenderer(value);
+};
 
 const formatDate = date => DateTime.fromISO(date).toFormat('dd/M/yyyy');
 
 const renderInfoIcon = () => <InfoButton dark slugs="" />;
-
-const handleOpenLink = link => window.open(link, '_blank');
 
 const table = indicator => (
   <React.Fragment key={`${indicator.title}-table`}>
@@ -47,20 +67,7 @@ const table = indicator => (
               {columnNames[column]}
             </td>
             <td className={cx(styles.cell)}>
-              {
-                indicator[column] &&
-                  (isLink(column)
-                    ? (
-                      <button
-                        type="button"
-                        onClick={() => handleOpenLink(indicator[column])}
-                        className={styles.link}
-                      >
-                      Link
-                      </button>
-)
-                    : <ReactMarkdown source={indicator[column]} />)
-              }
+              {renderColumnValue(indicator, column)}
             </td>
           </tr>
         ))}

--- a/app/models/climate_policy/indicator.rb
+++ b/app/models/climate_policy/indicator.rb
@@ -5,10 +5,8 @@
 #  id                    :bigint(8)        not null, primary key
 #  attainment_date       :string
 #  category              :string
-#  data_source_link      :text
 #  name                  :text
 #  responsible_authority :text
-#  sources               :text
 #  status                :text
 #  tracking_frequency    :string
 #  tracking_notes        :text
@@ -29,5 +27,6 @@
 module ClimatePolicy
   class Indicator < ApplicationRecord
     belongs_to :policy
+    has_and_belongs_to_many :sources
   end
 end

--- a/app/models/climate_policy/instrument.rb
+++ b/app/models/climate_policy/instrument.rb
@@ -12,7 +12,6 @@
 #  policy_scheme           :string
 #  policy_status           :text
 #  scheme                  :text
-#  source                  :text
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  policy_id               :bigint(8)
@@ -30,6 +29,7 @@
 module ClimatePolicy
   class Instrument < ApplicationRecord
     belongs_to :policy
+    has_and_belongs_to_many :sources
 
     validates_presence_of :code, :name
     validates :code, uniqueness: true

--- a/app/models/climate_policy/instrument.rb
+++ b/app/models/climate_policy/instrument.rb
@@ -31,7 +31,6 @@ module ClimatePolicy
     belongs_to :policy
     has_and_belongs_to_many :sources
 
-    validates_presence_of :code, :name
-    validates :code, uniqueness: true
+    validates_presence_of :name
   end
 end

--- a/app/models/climate_policy/milestone.rb
+++ b/app/models/climate_policy/milestone.rb
@@ -3,7 +3,6 @@
 # Table name: climate_policy_milestones
 #
 #  id                    :bigint(8)        not null, primary key
-#  data_source_link      :text
 #  date                  :string
 #  name                  :string
 #  responsible_authority :text
@@ -11,18 +10,22 @@
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  policy_id             :bigint(8)
+#  source_id             :bigint(8)
 #
 # Indexes
 #
 #  index_climate_policy_milestones_on_policy_id  (policy_id)
+#  index_climate_policy_milestones_on_source_id  (source_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (policy_id => climate_policy_policies.id) ON DELETE => cascade
+#  fk_rails_...  (source_id => climate_policy_sources.id) ON DELETE => cascade
 #
 
 module ClimatePolicy
   class Milestone < ApplicationRecord
     belongs_to :policy
+    belongs_to :source, optional: true
   end
 end

--- a/app/models/climate_policy/source.rb
+++ b/app/models/climate_policy/source.rb
@@ -17,6 +17,10 @@
 
 module ClimatePolicy
   class Source < ApplicationRecord
+    has_and_belongs_to_many :instruments
+    has_and_belongs_to_many :indicators
+    has_many :milestones
+
     validates :code, presence: true, uniqueness: true
   end
 end

--- a/app/serializers/api/v1/climate_policy/indicator_serializer.rb
+++ b/app/serializers/api/v1/climate_policy/indicator_serializer.rb
@@ -4,9 +4,13 @@ module Api
       class IndicatorSerializer < ActiveModel::Serializer
         attribute :name, key: :title
         attributes :category, :attainment_date, :value,
-                   :responsible_authority, :data_source_link,
+                   :responsible_authority,
                    :tracking_frequency, :tracking_notes,
                    :status, :sources, :updated_at
+
+        def sources
+          object.sources.map(&:link).join(' ')
+        end
       end
     end
   end

--- a/app/serializers/api/v1/climate_policy/indicator_serializer.rb
+++ b/app/serializers/api/v1/climate_policy/indicator_serializer.rb
@@ -6,11 +6,9 @@ module Api
         attributes :category, :attainment_date, :value,
                    :responsible_authority,
                    :tracking_frequency, :tracking_notes,
-                   :status, :sources, :updated_at
+                   :status, :updated_at
 
-        def sources
-          object.sources.map(&:link).join(' ')
-        end
+        has_many :sources, serializer: Api::V1::ClimatePolicy::SourceMiniSerializer
       end
     end
   end

--- a/app/serializers/api/v1/climate_policy/instrument_serializer.rb
+++ b/app/serializers/api/v1/climate_policy/instrument_serializer.rb
@@ -3,9 +3,13 @@ module Api
     module ClimatePolicy
       class InstrumentSerializer < ActiveModel::Serializer
         attribute :name, key: :title
-        attributes :code, :description, :policy_scheme, :scheme,
+        attributes :description, :policy_scheme, :scheme,
                    :policy_status, :key_milestones, :implementation_entities,
                    :broader_context, :source, :updated_at
+
+        def source
+          object.sources.first&.link
+        end
       end
     end
   end

--- a/app/serializers/api/v1/climate_policy/milestone_serializer.rb
+++ b/app/serializers/api/v1/climate_policy/milestone_serializer.rb
@@ -3,6 +3,10 @@ module Api
     module ClimatePolicy
       class MilestoneSerializer < ActiveModel::Serializer
         attributes :name, :responsible_authority, :date, :data_source_link, :status
+
+        def data_source_link
+          object.source&.link
+        end
       end
     end
   end

--- a/app/serializers/api/v1/climate_policy/source_mini_serializer.rb
+++ b/app/serializers/api/v1/climate_policy/source_mini_serializer.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    module ClimatePolicy
+      class SourceMiniSerializer < ActiveModel::Serializer
+        attributes :code, :link
+      end
+    end
+  end
+end

--- a/db/migrate/20190123150301_climate_policy_sources_enforce_relations.rb
+++ b/db/migrate/20190123150301_climate_policy_sources_enforce_relations.rb
@@ -1,0 +1,22 @@
+class ClimatePolicySourcesEnforceRelations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :climate_policy_instruments_sources do |t|
+      t.references :source, foreign_key: {to_table: :climate_policy_sources, on_delete: :cascade}
+      t.references :instrument, foreign_key: {to_table: :climate_policy_instruments, on_delete: :cascade}
+    end
+    create_table :climate_policy_indicators_sources do |t|
+      t.references :source, foreign_key: {to_table: :climate_policy_sources, on_delete: :cascade}
+      t.references :indicator, foreign_key: {to_table: :climate_policy_indicators, on_delete: :cascade}
+    end
+
+    remove_column :climate_policy_instruments, :source, :text
+    remove_column :climate_policy_indicators, :sources, :text
+    remove_column :climate_policy_indicators, :data_source_link, :text
+
+    remove_column :climate_policy_milestones, :data_source_link, :text
+    add_reference :climate_policy_milestones, :source, foreign_key: {
+                    to_table: :climate_policy_sources,
+                    on_delete: :cascade
+                  }, index: true
+  end
+end

--- a/db/migrate/20190123182107_remove_code_from_climate_policy_instruments.rb
+++ b/db/migrate/20190123182107_remove_code_from_climate_policy_instruments.rb
@@ -1,0 +1,5 @@
+class RemoveCodeFromClimatePolicyInstruments < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :climate_policy_instruments, :code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_21_162127) do
+ActiveRecord::Schema.define(version: 2019_01_23_150301) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,14 +52,19 @@ ActiveRecord::Schema.define(version: 2019_01_21_162127) do
     t.string "value"
     t.string "attainment_date"
     t.text "responsible_authority"
-    t.text "data_source_link"
     t.string "tracking_frequency"
     t.text "tracking_notes"
     t.text "status"
-    t.text "sources"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["policy_id"], name: "index_climate_policy_indicators_on_policy_id"
+  end
+
+  create_table "climate_policy_indicators_sources", force: :cascade do |t|
+    t.bigint "source_id"
+    t.bigint "indicator_id"
+    t.index ["indicator_id"], name: "index_climate_policy_indicators_sources_on_indicator_id"
+    t.index ["source_id"], name: "index_climate_policy_indicators_sources_on_source_id"
   end
 
   create_table "climate_policy_instruments", force: :cascade do |t|
@@ -73,11 +78,17 @@ ActiveRecord::Schema.define(version: 2019_01_21_162127) do
     t.text "key_milestones"
     t.text "implementation_entities"
     t.text "broader_context"
-    t.text "source"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_climate_policy_instruments_on_code", unique: true
     t.index ["policy_id"], name: "index_climate_policy_instruments_on_policy_id"
+  end
+
+  create_table "climate_policy_instruments_sources", force: :cascade do |t|
+    t.bigint "source_id"
+    t.bigint "instrument_id"
+    t.index ["instrument_id"], name: "index_climate_policy_instruments_sources_on_instrument_id"
+    t.index ["source_id"], name: "index_climate_policy_instruments_sources_on_source_id"
   end
 
   create_table "climate_policy_milestones", force: :cascade do |t|
@@ -86,10 +97,11 @@ ActiveRecord::Schema.define(version: 2019_01_21_162127) do
     t.text "responsible_authority"
     t.string "date"
     t.string "status"
-    t.text "data_source_link"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "source_id"
     t.index ["policy_id"], name: "index_climate_policy_milestones_on_policy_id"
+    t.index ["source_id"], name: "index_climate_policy_milestones_on_source_id"
   end
 
   create_table "climate_policy_policies", force: :cascade do |t|
@@ -250,8 +262,13 @@ ActiveRecord::Schema.define(version: 2019_01_21_162127) do
   end
 
   add_foreign_key "climate_policy_indicators", "climate_policy_policies", column: "policy_id", on_delete: :cascade
+  add_foreign_key "climate_policy_indicators_sources", "climate_policy_indicators", column: "indicator_id", on_delete: :cascade
+  add_foreign_key "climate_policy_indicators_sources", "climate_policy_sources", column: "source_id", on_delete: :cascade
   add_foreign_key "climate_policy_instruments", "climate_policy_policies", column: "policy_id", on_delete: :cascade
+  add_foreign_key "climate_policy_instruments_sources", "climate_policy_instruments", column: "instrument_id", on_delete: :cascade
+  add_foreign_key "climate_policy_instruments_sources", "climate_policy_sources", column: "source_id", on_delete: :cascade
   add_foreign_key "climate_policy_milestones", "climate_policy_policies", column: "policy_id", on_delete: :cascade
+  add_foreign_key "climate_policy_milestones", "climate_policy_sources", column: "source_id", on_delete: :cascade
   add_foreign_key "datasets", "sections"
   add_foreign_key "historical_emissions_records", "historical_emissions_data_sources", column: "data_source_id", on_delete: :cascade
   add_foreign_key "historical_emissions_records", "historical_emissions_gases", column: "gas_id", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_23_150301) do
+ActiveRecord::Schema.define(version: 2019_01_23_182107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,7 +69,6 @@ ActiveRecord::Schema.define(version: 2019_01_23_150301) do
 
   create_table "climate_policy_instruments", force: :cascade do |t|
     t.bigint "policy_id"
-    t.string "code", null: false
     t.string "name", null: false
     t.string "policy_scheme"
     t.text "description"
@@ -80,7 +79,6 @@ ActiveRecord::Schema.define(version: 2019_01_23_150301) do
     t.text "broader_context"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["code"], name: "index_climate_policy_instruments_on_code", unique: true
     t.index ["policy_id"], name: "index_climate_policy_instruments_on_policy_id"
   end
 

--- a/spec/factories/climate_policy_indicator.rb
+++ b/spec/factories/climate_policy_indicator.rb
@@ -6,10 +6,10 @@ FactoryBot.define do
     value { '1,475,000 (USD)' }
     attainment_date { '03/01/2016' }
     responsible_authority { 'UNDP-GEF' }
-    data_source_link { 'link' }
     tracking_frequency { 'Annually' }
     tracking_notes { 'notes' }
     status { 'Attained' }
-    sources { 'sources' }
+
+    sources { create_list(:climate_policy_source, 2) }
   end
 end

--- a/spec/factories/climate_policy_instrument.rb
+++ b/spec/factories/climate_policy_instrument.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :climate_policy_instrument, class: 'ClimatePolicy::Instrument' do
     association :policy, factory: :climate_policy
-    sequence(:code) { |n| "code_#{n}" }
     policy_scheme { 'Energy Conservation Building Code' }
     name { 'ECBC' }
     description { 'policy instrument description' }
@@ -10,6 +9,7 @@ FactoryBot.define do
     key_milestones { 'Key milestones' }
     implementation_entities { 'Implementation entities' }
     broader_context { 'Some context here' }
-    source { 'IER2017' }
+
+    sources { create_list(:climate_policy_source, 2) }
   end
 end

--- a/spec/factories/climate_policy_milestone.rb
+++ b/spec/factories/climate_policy_milestone.rb
@@ -1,10 +1,11 @@
 FactoryBot.define do
   factory :climate_policy_milestone, class: 'ClimatePolicy::Milestone' do
     association :policy, factory: :climate_policy
+    association :source, factory: :climate_policy_source
+
     name { 'ECBC integrated in GRIHA ' }
     responsible_authority { 'BEE' }
     date { 'August 2010' }
-    data_source_link { 'link' }
     status { 'Attained' }
   end
 end

--- a/spec/fixtures/files/climate_policy/indicators.csv
+++ b/spec/fixtures/files/climate_policy/indicators.csv
@@ -1,5 +1,5 @@
-policy_code,i_codes,type,name,attainment_date,unit,responsible_authority,data_source_link,tracking_frequency,tracking_notes,status,sources
-ECBC,ECBC.1,Finance,"UNDP-GEF-BEE programme ,GEF provides funding for various activities to promote ECBC implementation",Apr-17,5.2 million (USD),UNDP-GEF,http://www.in.undp.org/content/dam/india/docs/energy_efficiency_improvements_in_commercial_buildings_project_document.pdf,Annually,"Annual Project Review/Project Implementation Reports (APR/PIR): These key reports are prepared
+policy_code,type,name,attainment_date,unit,responsible_authority,tracking_frequency,tracking_notes,status,sources
+ECBC,Finance,"UNDP-GEF-BEE programme ,GEF provides funding for various activities to promote ECBC implementation",Apr-17,5.2 million (USD),UNDP-GEF,Annually,"Annual Project Review/Project Implementation Reports (APR/PIR): These key reports are prepared
 to monitor progress made since project start and in particular for the previous reporting period (30 June to
 1 July). The APR/PIR combines both UNDP and GEF reporting requirements.",5.01million USD disbursed by GEF,UNDP-EECB
-ECBC,ECBC.1,Others,Issue of CPWD guidelines for sustainable habitat,Mar-14,Guildelines,CPWD,http://cpwd.gov.in/publication/guideleines_sustainable_habitat.pdf,-,-,Issued,CPWD-GSH
+ECBC,Others,Issue of CPWD guidelines for sustainable habitat,Mar-14,Guildelines,CPWD,-,-,Issued,CPWD-GSH

--- a/spec/fixtures/files/climate_policy/instruments.csv
+++ b/spec/fixtures/files/climate_policy/instruments.csv
@@ -1,8 +1,8 @@
 policy_code,policy_scheme,code,name,description,scheme,status,key_milestones,implementation_entities,broader_context,sources
-ECBC,Energy Conservation Building Code,ECBC.1,ECBC,"Under its statutory authority, the Bureau of Energy Efficiency (BEE) with the support of the Ministry of Power (MoP)  launched the Energy Conservation Building Code (ECBC) in 2007.  The purpose of this code is to provide minimum requirements for the energy-efficient design and construction of buildings.
+ECBC,Energy Conservation Building Code,ECBC,"Under its statutory authority, the Bureau of Energy Efficiency (BEE) with the support of the Ministry of Power (MoP)  launched the Energy Conservation Building Code (ECBC) in 2007.  The purpose of this code is to provide minimum requirements for the energy-efficient design and construction of buildings.
 
  ECBC Version 2 was launched in June 2017 .ECBC 2017 was developed by BEE with technical support from United States Agency for International Development (USAID) under the U.S.-India bilateral Partnership to Advance Clean Energy – Deployment Technical Assistance (PACE-D TA) Program.
-",N/A,"* Launched at National level 
+",N/A,"* Launched at National level
 
 * Notified by 12 States","* ECBC version 1 launched in May 2007
 * ECBC version 2 launched in June,2017
@@ -12,7 +12,7 @@ The Government of India set up Bureau of Energy Efficiency (BEE). on 1st March 2
 
 **State Designated Authorities (SDA)**
 
-The responsibility of adoption and implementation of the ECBC code lies with the state authorities.The  adoption tasks included Setting up of ECBC Committee to implement the code,review ECBC and customize the code to suit regional and climatic conditions,define criteria of applicable building types,make legal notification in the state,gazette for mandatory implementation of the code. 
+The responsibility of adoption and implementation of the ECBC code lies with the state authorities.The  adoption tasks included Setting up of ECBC Committee to implement the code,review ECBC and customize the code to suit regional and climatic conditions,define criteria of applicable building types,make legal notification in the state,gazette for mandatory implementation of the code.
 
 **Urban Local Bodies(ULB)**
 The ECBC code execution is the responsibility of ULB.The local government requires to setup an  Institutionalized mechanisms for enforcement and compliance checking designate an Electrical Inspectorate, Setup robust monitoring and verification (M&V) system","The Energy Conservation Building Code (ECBC), was launched by Ministry of Power, Government of India, as a first step towards promoting energy efficiency in the building sector. ECBC is the most major initiative outlined in the National Mission on Sustainable Habitat.The focus was on developing and launching ECBC with the objective to make a difference in the commercial building sector that was projected to grow rapidly over the next 2-3 decades. The launch of ECBC promoted significant advancement in domain specific activities such as availability of energy efficient building materials and equipment, development of credible research institutions, laboratory and R&D facilities, uptake of green building rating programs and enlargement of a pool of energyefficient building experts.

--- a/spec/fixtures/files/climate_policy/milestones.csv
+++ b/spec/fixtures/files/climate_policy/milestones.csv
@@ -1,3 +1,3 @@
-policy_code,name,responsible_authority,date,data_source_link,status
-ECBC,The Energy Conservation Act (EC Act) was enacted on  at the central level to facilitate the implementation of the EC Act,Ministry of  Power,Oct-01,https://powermin.nic.in/sites/default/files/uploads/ecact2001.pdf,Attained
-ECBC,Bureau of Energy Efficiency (BEE) was set up as the statutory body ,Ministry of Power,Mar-02,https://beeindia.gov.in/,Attained
+policy_code,name,responsible_authority,date,source,status
+ECBC,The Energy Conservation Act (EC Act) was enacted on  at the central level to facilitate the implementation of the EC Act,Ministry of  Power,Oct-01,UNDP-EECB,Attained
+ECBC,Bureau of Energy Efficiency (BEE) was set up as the statutory body ,Ministry of Power,Mar-02,UNDP-EECB,Attained

--- a/spec/fixtures/files/climate_policy/sources.csv
+++ b/spec/fixtures/files/climate_policy/sources.csv
@@ -1,3 +1,5 @@
 code,name,description,link
 UNDP-EECB,United Nations Development Program - Energy Efficiency Improvements in Commercial Buildings,fake description,http://www.in.undp.org/content/india/en/home/operations/projects/environment_and_energy/energy_efficiencyimprovementsincommercialbuildings.html
 UNDP-2012,United Nations Development Program - 2012,fake description,http://www.in.undp.org/content/dam/india/docs/energy_efficiency_improvements_in_commercial_buildings_AWP2012.pdf
+IER2017,India Energy Report,,http://indiaenergy.gov.in/wp-content/uploads/2017/10/ECBC_report.pdf
+CPWD-GSH,Central Public Works Department - Guidelines for Sustainable Habitat,,http://cpwd.gov.in/publication/guideleines_sustainable_habitat.pdf

--- a/spec/models/climate_policy/instrument_spec.rb
+++ b/spec/models/climate_policy/instrument_spec.rb
@@ -8,22 +8,9 @@ RSpec.describe ClimatePolicy::Instrument, type: :model do
     expect(subject).to have(1).errors_on(:policy)
   end
 
-  it 'should be invalid when code not present' do
-    subject.code = nil
-    expect(subject).to have(1).errors_on(:code)
-  end
-
   it 'should be invalid when name not present' do
     subject.name = nil
     expect(subject).to have(1).errors_on(:name)
-  end
-
-  it 'should be invalid when code is taken' do
-    FactoryBot.create(:climate_policy_instrument, code: 'code')
-    subject.code = 'code'
-    expect(
-      subject
-    ).to have(1).errors_on(:code)
   end
 
   it 'should be valid' do

--- a/spec/models/climate_policy/milestone_spec.rb
+++ b/spec/models/climate_policy/milestone_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe ClimatePolicy::Milestone, type: :model do
     expect(subject).to have(1).errors_on(:policy)
   end
 
+  it 'should be valid without source' do
+    subject.source = nil
+    expect(subject).to be_valid
+  end
+
   it 'should be valid' do
     expect(subject).to be_valid
   end

--- a/spec/services/import_climate_policies_spec.rb
+++ b/spec/services/import_climate_policies_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ImportClimatePolicies do
   def missing_headers
     @missing_headers ||= {
       ImportClimatePolicies::POLICIES_FILEPATH => remove_headers(csv[:policies], :category),
-      ImportClimatePolicies::INSTRUMENTS_FILEPATH => remove_headers(csv[:instruments], :code),
+      ImportClimatePolicies::INSTRUMENTS_FILEPATH => remove_headers(csv[:instruments], :policy_code),
       ImportClimatePolicies::INDICATORS_FILEPATH => remove_headers(csv[:indicators], :name, :type),
       ImportClimatePolicies::MILESTONES_FILEPATH => remove_headers(csv[:milestones], :name),
       ImportClimatePolicies::SOURCES_FILEPATH => remove_headers(csv[:sources], :name)
@@ -61,7 +61,7 @@ RSpec.describe ImportClimatePolicies do
     end
 
     it 'Creates new source' do
-      expect { subject }.to change { ClimatePolicy::Source.count }.by(2)
+      expect { subject }.to change { ClimatePolicy::Source.count }.by(4)
     end
 
     describe 'Imported record' do
@@ -78,7 +78,11 @@ RSpec.describe ImportClimatePolicies do
       end
 
       describe 'instrument' do
-        subject { ClimatePolicy::Instrument.find_by!(code: 'ECBC.1') }
+        subject do
+          ClimatePolicy::Instrument.
+            includes(:policy).
+            find_by!(climate_policy_policies: {code: 'ECBC'})
+        end
 
         it 'has all attributes populated' do
           subject.attributes.each do |attr, value|


### PR DESCRIPTION
Cleaning up sources for climate policies after WRI data changes.

```
bundle exec rake db:migrate
bundle exec rake db:import
```

Don't worry about many errors while importing. They are still working on that data.

Story link: https://www.pivotaltracker.com/story/show/163022783