### PR TITLE
Store files locally - fix production config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,6 +70,10 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
+  # Store files locally - upload to S3 happens with the use of a gem, not through active storage :amazon option
+  # active storage doesn't allow uploading to nested folders
+  config.active_storage.service = :local
+
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 


### PR DESCRIPTION
Currently uploading files in production fails because the active storage config's missing in production environment. 
`config.active_storage.service` is set to `:local` in both development.rb and production.rb. Initial goal was to use `:amazon` option to directly upload to S3 through Active Storage without the use of a gem but Active Storage doesn't support nested folders structure and it acts as an intermediary between the app and S3.