### PR TITLE
Fix text overflow for Climate Policies/Overview & fix footer position

### DIFF
--- a/app/javascript/app/layouts/root/root-styles.scss
+++ b/app/javascript/app/layouts/root/root-styles.scss
@@ -10,4 +10,5 @@
 
 .appContent {
   padding-top: $header-height;
+  min-height: calc(100vh - 42px);
 }

--- a/app/javascript/app/pages/climate-policies/overview/overview-styles.scss
+++ b/app/javascript/app/pages/climate-policies/overview/overview-styles.scss
@@ -17,8 +17,6 @@ $line-height: 1.5rem; // 24px
   }
 
   @media #{$tablet-landscape} {
-    height: 600px;
-
     @include columns((6, 6));
   }
 }


### PR DESCRIPTION
This PR fixes text overflow on Climate Policy's Overview Page
[Pivotal task](https://www.pivotaltracker.com/story/show/163754171)
**BEFORE:**
![screenshot from 2019-02-15 17 15 13](https://user-images.githubusercontent.com/15097138/52872843-6647d980-3145-11e9-805c-31c8b3a34359.png)

**NOW:**
![screenshot from 2019-02-15 17 15 53](https://user-images.githubusercontent.com/15097138/52872865-75c72280-3145-11e9-9009-ccaae0dbdb06.png)
