### PR TITLE
fix db setup when db does not exists

### DIFF
--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -26,6 +26,7 @@ begin
 
     I18n.backend = I18n::Backend::Chain.new(I18n.backend, I18n::Backend::Simple.new)
   end
-rescue PG::ConnectionBad
-  puts "Database not connected - not initializing I18n backend"
+rescue PG::ConnectionBad, ActiveRecord::NoDatabaseError
+  puts $!
+  puts "Skipping I18n DB backend initialization"
 end


### PR DESCRIPTION
Something must have changed in Rails 5.2 with initializers and now they are all invoked even for db creation task. This PR fixes `rake db:setup` task when the database does not exist yet.

To test:

```
bundle exec rake db:drop
bundle exec rake db:setup
```