### PR TITLE
Feature/rename sections national context

### DIFF
--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-component.jsx
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-component.jsx
@@ -42,7 +42,7 @@ class Population extends PureComponent {
         <Switch
           options={[
             { name: 'population', value: 'CAIT' },
-            { name: 'population by gender', value: 'age_and_gender' },
+            { name: 'population by gender', value: 'population_by_gender' },
             { name: 'Human Development Index', value: 'hdi' }
           ]}
           value={selectedSource}

--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-component.jsx
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-component.jsx
@@ -41,8 +41,8 @@ class Population extends PureComponent {
         />
         <Switch
           options={[
-            { name: 'CAIT', value: 'CAIT' },
-            { name: 'Age and gender', value: 'age_and_gender' },
+            { name: 'population', value: 'CAIT' },
+            { name: 'population by gender', value: 'age_and_gender' },
             { name: 'Human Development Index', value: 'hdi' }
           ]}
           value={selectedSource}

--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-selectors.js
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-selectors.js
@@ -20,7 +20,7 @@ const DEFAULT_STATE = 'Delhi';
 // Total population
 const DEFAULT_INDICATOR = {
   CAIT: 'population_3',
-  age_and_gender: 'Sex_ratio',
+  population_by_gender: 'Sex_ratio',
   hdi: 'hdi'
 };
 const INDICATOR_CODES = {
@@ -31,7 +31,7 @@ const INDICATOR_CODES = {
     'population_4',
     'pop_density'
   ],
-  age_and_gender: [ 'Sex_ratio' ],
+  population_by_gender: [ 'Sex_ratio' ],
   hdi: [ 'hdi' ]
 };
 const DATA_SCALE = 1000;


### PR DESCRIPTION
This PR changes names of Population subsections (Country Context/Socioeconomic Indicators):

- CAIT-SOURCE to POPULATION

- AGE AND GENDER to POPULATION BY GENDER


[PIVOTAL](https://www.pivotaltracker.com/story/show/164174629) | [BASECAMP 1](https://basecamp.com/1756858/projects/15229632/todos/378929390) | [BASECAMP 2](https://basecamp.com/1756858/projects/15229632/todos/379869409)

![screenshot from 2019-02-25 11 43 50](https://user-images.githubusercontent.com/15097138/53335169-a865dd80-38f2-11e9-9b12-b25ab840d04f.png)
