### PR TITLE
Feature/add climate policies button

### DIFF
--- a/app/javascript/app/pages/home/home-component.jsx
+++ b/app/javascript/app/pages/home/home-component.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Section } from 'cw-components';
+import { Section, Button } from 'cw-components';
 import background from 'assets/header';
 import SectionTitle from 'components/section-title';
 import sectionImage from 'assets/home/image@1x';
 import sectionRetinaImage from 'assets/home/image@2x';
+import buttonThemes from 'styles/themes/button';
 
 import CwDisclaimer from './cw-disclaimer';
 import HighlightedStories from './stories';
@@ -24,6 +25,12 @@ const renderClimatePoliciesSection = t => (
         title={t('pages.home.progress-of-climate-policies.title')}
         description={t('pages.home.progress-of-climate-policies.description')}
       />
+      <Button
+        theme={{ button: buttonThemes.white }}
+        link={{ type: 'a', props: { href: '/climate-policies' } }}
+      >
+        Go To Climate Policies
+      </Button>
     </div>
   </div>
 );

--- a/app/javascript/app/pages/home/home-component.jsx
+++ b/app/javascript/app/pages/home/home-component.jsx
@@ -5,6 +5,7 @@ import background from 'assets/header';
 import SectionTitle from 'components/section-title';
 import sectionImage from 'assets/home/image@1x';
 import sectionRetinaImage from 'assets/home/image@2x';
+import cx from 'classnames';
 import buttonThemes from 'styles/themes/button';
 
 import CwDisclaimer from './cw-disclaimer';
@@ -26,7 +27,7 @@ const renderClimatePoliciesSection = t => (
         description={t('pages.home.progress-of-climate-policies.description')}
       />
       <Button
-        theme={{ button: buttonThemes.white }}
+        theme={{ button: cx(buttonThemes.primary, styles.button) }}
         link={{ type: 'a', props: { href: '/climate-policies' } }}
       >
         Go To Climate Policies

--- a/app/javascript/app/pages/home/home-component.jsx
+++ b/app/javascript/app/pages/home/home-component.jsx
@@ -30,7 +30,7 @@ const renderClimatePoliciesSection = t => (
         theme={{ button: cx(buttonThemes.primary, styles.button) }}
         link={{ type: 'a', props: { href: '/climate-policies' } }}
       >
-        Go To Climate Policies
+        {t('pages.home.progress-of-climate-policies.button')}
       </Button>
     </div>
   </div>

--- a/app/javascript/app/pages/home/home-styles.scss
+++ b/app/javascript/app/pages/home/home-styles.scss
@@ -94,7 +94,6 @@
 }
 
 .climatePoliciesWrapper {
-  align-items: center;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -104,4 +103,12 @@
     justify-content: flex-start;
     margin-bottom: 0;
   }
+}
+
+.button {
+  background-color: $white;
+  color: $elephant-blue;
+  max-width: 250px;
+  margin-bottom: 30px;
+  border: 1px solid rgba(26, 28, 34, 0.1);
 }

--- a/app/javascript/app/pages/home/home-styles.scss
+++ b/app/javascript/app/pages/home/home-styles.scss
@@ -94,6 +94,7 @@
 }
 
 .climatePoliciesWrapper {
+  align-items: center;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/config/locales/en/app/pages/home.yml
+++ b/config/locales/en/app/pages/home.yml
@@ -22,4 +22,5 @@ en:
         progress-of-climate-policies:
           title: Understand the progress of climate ￼policies
           description: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio.
+          button: Go to Climate Policies
         climate-watch-disclaimer: Improving understanding of the possible policy and development paths that could lead to decarbonization of the economy in different countries by providing high-quality, global data.


### PR DESCRIPTION
This small PR adds `Go to Climate Policies` button to `Understand the progress...` section.
![screenshot from 2019-02-26 11 14 49](https://user-images.githubusercontent.com/15097138/53409304-7cad2b00-39b8-11e9-8814-c0486185c015.png)

BTW. I think we should make our styles consistent with UI kit, because now it's a bit messy