### PR TITLE
Add top 10 key policies table to policies overview

### DIFF
--- a/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-component.jsx
+++ b/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-component.jsx
@@ -4,7 +4,7 @@ import { isEmpty } from 'lodash';
 import ClimatePoliciesProvider from 'providers/climate-policies-provider';
 import PoliciesCard from 'components/policies-card';
 import SearchCategoriesBox from 'components/search-categories-box';
-import { NoContent } from 'cw-components';
+import { NoContent, Table } from 'cw-components';
 
 import styles from './climate-policy-module-styles';
 
@@ -22,7 +22,8 @@ const ClimatePolicies = (
     onCheckboxChange,
     handleTagRemove,
     handleAllTagsRemove,
-    t
+    t,
+    keyPoliciesList
   }
 ) => (
   <div>
@@ -86,12 +87,34 @@ const ClimatePolicies = (
                 </div>
               </section>
             ))
-            : <NoContent
-              minHeight={300}
-              message="No data found with this search"
-            />
+            : (
+              <NoContent
+                minHeight={300}
+                message="No data found with this search"
+              />
+)
         }
       </section>
+      {
+        !isEmpty(keyPoliciesList) && (
+        <section className={styles.policyKeyListWrapper}>
+          <h2 className={styles.title}>
+            {t('pages.climate-policies.key-policies-header')}
+          </h2>
+          <Table
+            data={keyPoliciesList}
+            defaultColumns={[
+                  'policy',
+                  'policy_status',
+                  'policy_progress'
+                ]}
+            setColumnWidth={() => 370}
+            tableHeight={600}
+            dynamicRowsHeight
+          />
+        </section>
+          )
+      }
       <ClimatePoliciesProvider />
     </div>
   </div>
@@ -105,13 +128,15 @@ ClimatePolicies.propTypes = {
   onSearchChange: PropTypes.func.isRequired,
   handleTagRemove: PropTypes.func.isRequired,
   handleAllTagsRemove: PropTypes.func.isRequired,
-  onCheckboxChange: PropTypes.func.isRequired
+  onCheckboxChange: PropTypes.func.isRequired,
+  keyPoliciesList: PropTypes.arrayOf(PropTypes.shape({}))
 };
 
 ClimatePolicies.defaultProps = {
   policiesListBySector: {},
   sectors: null,
-  authorities: null
+  authorities: null,
+  keyPoliciesList: null
 };
 
 export default ClimatePolicies;

--- a/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
+++ b/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
@@ -40,10 +40,22 @@ const getFilteredPoliciesBySector = createSelector(
   }
 );
 
+const getKeyClimatePolicies = createSelector(getFilteredPolicies, policies => {
+  if (!policies) return null;
+  return policies
+    .filter(({ key_policy }) => key_policy)
+    .map(({ title, status, progress }) => ({
+      policy: title,
+      policy_status: status,
+      policy_progress: progress
+    }));
+});
+
 export const climatePolicies = createStructuredSelector({
   query: getQuery,
   policiesList: getFilteredPolicies,
   policiesListBySector: getFilteredPoliciesBySector,
   sectors: getSectors,
-  authorities: getResponsibleAuthorities
+  authorities: getResponsibleAuthorities,
+  keyPoliciesList: getKeyClimatePolicies
 });

--- a/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-styles.scss
+++ b/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-styles.scss
@@ -110,3 +110,14 @@
     @include columns(4);
   }
 }
+
+.policyKeyListWrapper {
+  margin-bottom: 250px;
+
+  .title {
+    @extend .sectionTitle;
+
+    color: $downriver;
+    font-size: $font-size-x-large;
+  }
+}


### PR DESCRIPTION
This PR adds table of 10 key policies to `Policy module` page:
[BASECAMP](https://basecamp.com/1756858/projects/15229632/todos/378284196) | [PIVOTAL](https://www.pivotaltracker.com/story/show/164210862) | [INVISION](https://projects.invisionapp.com/d/main#/console/15950314/330875047/preview)
![screenshot from 2019-02-27 17 38 00](https://user-images.githubusercontent.com/15097138/53510664-7309ed00-3ab6-11e9-8761-5f8fba412004.png)
