### PR TITLE
Climate policy multiple authorities filter fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,16 @@ These will create the development database and then run the database migration t
 You'll need to run both the rails server and the webpack server, which will be used internally by rails. Run, separately:
 
 ```
-bundle exec rails s
+yarn rails:server
 ```
 
 and
+
+```
+yarn js:server
+```
+
+or run both:
 
 ```
 yarn start

--- a/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
+++ b/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
@@ -1,5 +1,5 @@
 import { createStructuredSelector, createSelector } from 'reselect';
-import { isEmpty, groupBy, isArray } from 'lodash';
+import { isEmpty, groupBy, castArray } from 'lodash';
 
 import {
   getClimatePoliciesList,
@@ -20,10 +20,7 @@ const getFilteredPolicies = createSelector(
     return policies.reduce(
       (acc, policy) => {
         const notFiltered = filtersFieldsArray.find(
-          f =>
-            isArray(query[f])
-              ? query[f].includes(policy[f])
-              : policy[f].includes(query[f])
+          f => castArray(query[f]).some(q => policy[f].includes(q))
         );
         return notFiltered ? [ ...acc, policy ] : [ ...acc ];
       },

--- a/app/javascript/app/selectors/climate-policies-selectors.js
+++ b/app/javascript/app/selectors/climate-policies-selectors.js
@@ -1,5 +1,5 @@
 import { createSelector, createStructuredSelector } from 'reselect';
-import { groupBy } from 'lodash';
+import { flatMap, groupBy, uniq } from 'lodash';
 
 export const getClimatePoliciesList = ({ ClimatePolicies }) =>
   ClimatePolicies && (ClimatePolicies.data || null);
@@ -97,7 +97,10 @@ export const getResponsibleAuthorities = createSelector(
   getClimatePoliciesList,
   list => {
     if (!list) return null;
-    return Object.keys(groupBy(list, 'authority'));
+
+    return uniq(
+      flatMap(list, p => (p.authority || '').split(',').map(a => a.trim()))
+    ).sort();
   }
 );
 export const policiesByCode = createSelector(getClimatePoliciesList, list => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "cw-india",
   "version": "1.0.0",
   "scripts": {
-    "start": "./bin/webpack-dev-server",
+    "start": "yarn js:server & yarn rails:server",
+    "js:server": "yarn install && ./bin/webpack-dev-server",
+    "rails:server": "bundle exec rails s",
     "reinstall": "rm -rf ./node_modules && npm install",
     "precommit": "lint-staged",
     "lint": "eslint --ext js --ext jsx .",


### PR DESCRIPTION
Climate policy authorities are separated by commas.

Fixing the filter in overview page to remove duplicates and sort by name. Below you can see there are still some data issues, missing commas, in option 2 (I think) and 3, but that should be resolved by the client.

![image](https://user-images.githubusercontent.com/1286444/53808869-abe11080-3f53-11e9-8752-1900da428828.png)

https://www.pivotaltracker.com/story/show/164210812
