### PR TITLE
Feature/snapshot of progress text

### DIFF
--- a/app/javascript/app/components/chart/bar-tooltip-chart/bar-tooltip-chart-component.jsx
+++ b/app/javascript/app/components/chart/bar-tooltip-chart/bar-tooltip-chart-component.jsx
@@ -1,104 +1,78 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import { format } from 'd3-format';
 import sortBy from 'lodash/sortBy';
 import isNumber from 'lodash/isNumber';
 import isNil from 'lodash/isNil';
 import styles from './bar-tooltip-chart-styles';
 
+const renderValue = ({ formatFunction }, y) => {
+  const value = y.payload && y.payload[y.dataKey];
+
+  if (!value) return 'n/a';
+  if (formatFunction) return formatFunction(y);
+  return format(',')(value);
+};
+
 class BarTooltipChart extends PureComponent {
   getTotal() {
     const { content } = this.props;
     const payload = content && content.payload;
-    const total = payload &&
+    const total =
+      payload &&
       payload.length > 0 &&
-      payload.reduce(
-        (acc, current) => isNumber(current.value) ? acc + current.value : acc,
-        0
-      );
+      payload.reduce((acc, current) => (isNumber(current.value) ? acc + current.value : acc), 0);
     return total && format(',.4s')(total);
   }
 
-  sortByValue = payload => {
-    const yValues = payload[0].payload;
-    const compare = (a, b) => {
-      if (yValues[b.dataKey] === undefined) return -1;
-      if (yValues[a.dataKey] === undefined) return 1;
-      return yValues[b.dataKey] - yValues[a.dataKey];
-    };
-    return payload.sort(compare);
-  };
-
-  renderValue = y => {
-    const { getCustomValueFormat } = this.props;
-    const value = y.payload && y.payload[y.dataKey];
-
-    if (value !== undefined) {
-      if (getCustomValueFormat) {
-        return getCustomValueFormat(y);
-      }
-
-      return format(',')(value);
-    }
-    return 'n/a';
-  };
-
   render() {
-    const { config, content, showEmptyValues } = this.props;
-    const yUnit = config &&
-      config.axes &&
-      config.axes.yLeft &&
-      config.axes.yLeft.unit;
+    const { config, content, showEmptyValues, showTotal } = this.props;
+    const yUnit = config && config.axes && config.axes.yLeft && config.axes.yLeft.unit;
     const payload = content && content.payload;
+    const shouldShowTotal = showTotal && payload.length > 1;
 
     return (
       <div className={styles.tooltip}>
-        <div className={styles.tooltipHeader}>
-          <span>
-            {content.label}
-          </span>
-          <span>
-            {`${yUnit} ${this.getTotal()}`}
-          </span>
+        <div className={styles.tooltipRow}>
+          <span>{content.label}</span>
+          <span>{yUnit}</span>
         </div>
-        {
-          payload && payload.length > 0 && sortBy(payload, 'value').map(
-              y =>
-                y.payload &&
-                  y.dataKey !== 'total' &&
-                  config.tooltip[y.dataKey] &&
-                  config.tooltip[y.dataKey].label &&
-                  (showEmptyValues ||
-                    !showEmptyValues && !isNil(y.payload[y.dataKey]))
-                  ? (
-                    <div key={`${y.dataKey}`} className={styles.tooltipHeader}>
-                      {
-                      yUnit && (
-                      <span>
-                        <span
-                          className={styles.dot}
-                          style={{
-                                backgroundColor: config.theme[y.dataKey].stroke
-                              }}
-                        />
-                        <span
-                          className={styles.unit}
-                              /* eslint-disable-line*/
-                          dangerouslySetInnerHTML={{
-                                __html: config.tooltip[y.dataKey].label
-                              }}
-                        />
-                      </span>
-                        )
-                    }
-                      <span>
-                        {this.renderValue(y)}
-                      </span>
-                    </div>
-)
-                  : null
-            )
-        }
+        {shouldShowTotal && (
+          <div key="total" className={cx(styles.tooltipRow, styles.total)}>
+            <span>TOTAL</span>
+            <span>{this.getTotal()}</span>
+          </div>
+        )}
+        {payload &&
+          payload.length > 0 &&
+          sortBy(payload, 'value').map(y =>
+            y.payload &&
+            y.dataKey !== 'total' &&
+            config.tooltip[y.dataKey] &&
+            config.tooltip[y.dataKey].label &&
+            (showEmptyValues || (!showEmptyValues && !isNil(y.payload[y.dataKey]))) ? (
+              <div key={`${y.dataKey}`} className={styles.tooltipRow}>
+                {yUnit && (
+                  <span>
+                    <span
+                      className={styles.dot}
+                      style={{
+                        backgroundColor: config.theme[y.dataKey].stroke
+                      }}
+                    />
+                    <span
+                      className={styles.unit}
+                      /* eslint-disable-line*/
+                      dangerouslySetInnerHTML={{
+                        __html: config.tooltip[y.dataKey].label
+                      }}
+                    />
+                  </span>
+                )}
+                <span>{renderValue(config.tooltip, y)}</span>
+              </div>
+            ) : null)}
         {content && !content.payload && <div>No data available</div>}
       </div>
     );
@@ -108,15 +82,15 @@ class BarTooltipChart extends PureComponent {
 BarTooltipChart.propTypes = {
   content: PropTypes.object,
   config: PropTypes.object,
-  showEmptyValues: PropTypes.bool,
-  getCustomValueFormat: PropTypes.func
+  showTotal: PropTypes.bool,
+  showEmptyValues: PropTypes.bool
 };
 
 BarTooltipChart.defaultProps = {
   content: {},
   config: {},
-  showEmptyValues: true,
-  getCustomValueFormat: null
+  showTotal: true,
+  showEmptyValues: true
 };
 
 export default BarTooltipChart;

--- a/app/javascript/app/components/chart/bar-tooltip-chart/bar-tooltip-chart-styles.scss
+++ b/app/javascript/app/components/chart/bar-tooltip-chart/bar-tooltip-chart-styles.scss
@@ -9,7 +9,7 @@
   border-radius: 4px;
 }
 
-.tooltipHeader {
+.tooltipRow {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -28,6 +28,14 @@
 
   &:not(:first-child) {
     color: #77818c;
+  }
+}
+
+.total {
+  font-weight: $font-weight-bold;
+
+  > * {
+    color: #0e4762;
   }
 }
 

--- a/app/javascript/app/pages/climate-policies/progress/chart-display/chart-display-component.jsx
+++ b/app/javascript/app/pages/climate-policies/progress/chart-display/chart-display-component.jsx
@@ -15,9 +15,7 @@ class ChartDisplay extends PureComponent {
     const { onFilterChange, indicator } = this.props;
 
     const filter = `${indicator.code}_category`;
-    const values = isArray(selected)
-      ? selected.map(v => v.value).join(',')
-      : selected.value;
+    const values = isArray(selected) ? selected.map(v => v.value).join(',') : selected.value;
 
     onFilterChange({ [filter]: values });
   };
@@ -27,45 +25,34 @@ class ChartDisplay extends PureComponent {
 
     if (!indicator) return null;
 
-    const tooltip = (
-      <BarTooltipChart
-        showEmptyValues={false}
-        getCustomValueFormat={chartData.tooltipCustomValueFormat}
-      />
-    );
+    const tooltip = <BarTooltipChart showEmptyValues={false} />;
 
     return (
       <React.Fragment>
         <div className={styles.chartProgress}>
-          <div className={styles.indicatorTitle}>
-            {indicator.title}
-          </div>
+          <div className={styles.indicatorTitle}>{indicator.title}</div>
           <div className={styles.lastUpdate}>
-            <span className={styles.date}>
-              Last update: {formatDate(indicator.updated_at)}
-            </span>
+            <span className={styles.date}>Last update: {formatDate(indicator.updated_at)}</span>
             <InfoButton dark slugs="" />
           </div>
         </div>
         <div className={styles.chartContainer}>
-          {
-            chartData &&
-              (
-                <Chart
-                  type="bar"
-                  config={chartData.config}
-                  data={chartData.data}
-                  dataOptions={chartData.dataOptions}
-                  dataSelected={chartData.dataSelected}
-                  loading={false}
-                  domain={chartData.domain}
-                  height={300}
-                  barSize={50}
-                  customTooltip={tooltip}
-                  onLegendChange={this.handleLegendChange}
-                />
-              )
-          }
+          {chartData && (
+            <Chart
+              type="bar"
+              config={chartData.config}
+              data={chartData.data}
+              dataOptions={chartData.dataOptions}
+              dataSelected={chartData.dataSelected}
+              loading={false}
+              domain={chartData.domain}
+              height={300}
+              barSize={50}
+              customTooltip={tooltip}
+              showUnit
+              onLegendChange={this.handleLegendChange}
+            />
+          )}
         </div>
       </React.Fragment>
     );

--- a/app/javascript/app/pages/climate-policies/progress/chart-display/chart-display-component.jsx
+++ b/app/javascript/app/pages/climate-policies/progress/chart-display/chart-display-component.jsx
@@ -26,6 +26,7 @@ class ChartDisplay extends PureComponent {
     if (!indicator) return null;
 
     const tooltip = <BarTooltipChart showEmptyValues={false} />;
+    const margin = { top: 30, right: 0, left: -10, bottom: 0 };
 
     return (
       <React.Fragment>
@@ -46,6 +47,7 @@ class ChartDisplay extends PureComponent {
               dataSelected={chartData.dataSelected}
               loading={false}
               domain={chartData.domain}
+              margin={margin}
               height={300}
               barSize={50}
               customTooltip={tooltip}

--- a/app/javascript/app/pages/climate-policies/progress/chart-display/chart-display-selectors.js
+++ b/app/javascript/app/pages/climate-policies/progress/chart-display/chart-display-selectors.js
@@ -12,7 +12,7 @@ const getAllCategories = indicator =>
 
 const getAxes = indicator => ({
   xBottom: { name: 'AxisX', unit: '', format: 'string' },
-  yLeft: { name: 'Reporting value', unit: indicator.unit, format: 'number' }
+  yLeft: { name: 'Reporting value', unit: indicator.unit, format: 'number', label: { dy: 10 } }
 });
 
 const getSelectedCategories = indicator => state => {

--- a/app/javascript/app/pages/climate-policies/progress/chart-display/chart-display-selectors.js
+++ b/app/javascript/app/pages/climate-policies/progress/chart-display/chart-display-selectors.js
@@ -5,11 +5,7 @@ import groupBy from 'lodash/groupBy';
 import uniq from 'lodash/uniq';
 import { format } from 'd3-format';
 
-import {
-  getThemeConfig,
-  getYColumnValue,
-  getTooltipConfig
-} from 'utils/graphs';
+import { getThemeConfig, getYColumnValue, getTooltipConfig } from 'utils/graphs';
 
 const getAllCategories = indicator =>
   uniq(get(indicator, 'progress_records', []).map(r => r.category));
@@ -29,59 +25,62 @@ const getSelectedCategories = indicator => state => {
   return value.split(',');
 };
 
-export const getQuery = ({ location }) => location && location.query || null;
+export const getQuery = ({ location }) => (location && location.query) || null;
 export const getChartData = indicator =>
-  createSelector([ getSelectedCategories(indicator) ], selectedCategories => {
-    if (!get(indicator, 'progress_records.length')) return null;
+  createSelector(
+    [getSelectedCategories(indicator)],
+    selectedCategories => {
+      if (!get(indicator, 'progress_records.length')) return null;
 
-    const categories = getAllCategories(indicator);
-    const dataGroupedByAxisX = groupBy(indicator.progress_records, 'axis_x');
-    const categoryToLegendObject = c => ({ label: c, value: c });
+      const categories = getAllCategories(indicator);
+      const dataGroupedByAxisX = groupBy(indicator.progress_records, 'axis_x');
+      const categoryToLegendObject = c => ({ label: c, value: c });
 
-    const data = Object
-      .keys(dataGroupedByAxisX)
-      .map(axisX => ({
+      const data = Object.keys(dataGroupedByAxisX).map(axisX => ({
         x: axisX,
         ...dataGroupedByAxisX[axisX].reduce(
           (acc, d) => ({ ...acc, [getYColumnValue(d.category)]: d.value }),
           {}
         )
       }));
-    const yColumns = selectedCategories.map(c => ({
-      label: c,
-      value: getYColumnValue(c),
-      stackId: 'stack'
-    }));
-    const dataSelected = selectedCategories.map(categoryToLegendObject);
-    const dataOptions = categories.map(categoryToLegendObject);
-    const tooltipCustomValueFormat = y => {
-      const axis_x = get(y, 'payload.x');
-      const { value, dataKey } = y;
+      const yColumns = selectedCategories.map(c => ({
+        label: c,
+        value: getYColumnValue(c),
+        stackId: 'stack'
+      }));
+      const dataSelected = selectedCategories.map(categoryToLegendObject);
+      const dataOptions = categories.map(categoryToLegendObject);
+      const tooltipCustomValueFormat = y => {
+        const axis_x = get(y, 'payload.x');
+        const { value, dataKey } = y;
 
-      const record = indicator.progress_records.find(
-        d => d.axis_x === axis_x && getYColumnValue(d.category) === dataKey
-      );
-      const target = record && record.target;
-      const valueFormatted = format(',')(value);
+        const record = indicator.progress_records.find(
+          d => d.axis_x === axis_x && getYColumnValue(d.category) === dataKey
+        );
+        const target = record && record.target;
+        const valueFormatted = format(',')(value);
 
-      if (!target) return valueFormatted;
+        if (!target) return valueFormatted;
 
-      // return `${valueFormatted} / ${target}`;
-      return `${valueFormatted} (target: ${target})`;
-    };
+        // return `${valueFormatted} / ${target}`;
+        return `${valueFormatted} (target: ${target})`;
+      };
 
-    return {
-      data,
-      dataOptions,
-      dataSelected,
-      domain: { x: [ 'auto', 'auto' ], y: [ 0, 'auto' ] },
-      tooltipCustomValueFormat,
-      config: {
-        axes: getAxes(indicator),
-        animation: false,
-        columns: { x: [ { label: '', value: 'x' } ], y: yColumns },
-        theme: getThemeConfig(yColumns),
-        tooltip: getTooltipConfig(yColumns)
-      }
-    };
-  });
+      return {
+        data,
+        dataOptions,
+        dataSelected,
+        domain: { x: ['auto', 'auto'], y: [0, 'auto'] },
+        config: {
+          axes: getAxes(indicator),
+          animation: false,
+          columns: { x: [{ label: '', value: 'x' }], y: yColumns },
+          theme: getThemeConfig(yColumns),
+          tooltip: {
+            ...getTooltipConfig(yColumns),
+            formatFunction: tooltipCustomValueFormat
+          }
+        }
+      };
+    }
+  );

--- a/app/javascript/app/pages/climate-policies/progress/text-display/text-display-component.jsx
+++ b/app/javascript/app/pages/climate-policies/progress/text-display/text-display-component.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactMarkdown from 'react-markdown';
 
 import { formatDate } from 'utils';
 import InfoButton from 'components/info-button';
 
 import styles from './text-display-styles';
-
-const normalizeValue = value =>
-  Number.isNaN(Number(value)) ? value : Number(value).toString();
-
-const showCategoryWithValue = progress =>
-  [ progress.axis_x, normalizeValue(progress.value) ].filter(x => x).join(': ');
 
 const TextDisplay = ({ indicator }) => (
   <div className={styles.textProgress}>
@@ -19,9 +14,8 @@ const TextDisplay = ({ indicator }) => (
     </div>
     <ul>
       {indicator.progress_records.map(progress => (
-        <li key={progress.axis_x}>
-          {showCategoryWithValue(progress)}
-          {indicator.unit && ` ${indicator.unit}`}
+        <li key={progress.value}>
+          <ReactMarkdown source={progress.value} escapeHtml={false} />
         </li>
       ))}
     </ul>

--- a/app/models/climate_policy/progress_record.rb
+++ b/app/models/climate_policy/progress_record.rb
@@ -6,7 +6,7 @@
 #  axis_x       :string
 #  category     :string
 #  target       :string
-#  value        :float            not null
+#  value        :float
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  indicator_id :bigint(8)

--- a/app/serializers/api/v1/climate_policy/progress_record_serializer.rb
+++ b/app/serializers/api/v1/climate_policy/progress_record_serializer.rb
@@ -4,6 +4,12 @@ module Api
       class ProgressRecordSerializer < ActiveModel::Serializer
         attributes :axis_x, :category, :value, :target
 
+        def value
+          return object.value.to_f unless object.indicator.text?
+
+          object.value
+        end
+
         def category
           object.category || 'Reporting value'
         end

--- a/app/serializers/api/v1/climate_policy/progress_record_serializer.rb
+++ b/app/serializers/api/v1/climate_policy/progress_record_serializer.rb
@@ -11,7 +11,7 @@ module Api
         end
 
         def category
-          object.category || 'Reporting value'
+          object.category || object.indicator.name
         end
       end
     end

--- a/app/services/import_climate_policies.rb
+++ b/app/services/import_climate_policies.rb
@@ -209,13 +209,22 @@ class ImportClimatePolicies
   end
 
   def progress_attributes(row)
+    indicator = find_indicator!(row[:indicator_code])
+
     {
-      indicator: find_indicator!(row[:indicator_code]),
+      indicator: indicator,
       axis_x: row[:axis_x],
       category: row[:category],
-      value: row[:value]&.delete('%,', ',')&.to_f,
+      value: parse_progress_value(indicator, row[:value]),
       target: parse_target(row[:target])
     }
+  end
+
+  def parse_progress_value(indicator, value)
+    return unless value.present?
+    return value.delete('%,', ',')&.to_f unless indicator.text?
+
+    value
   end
 
   # we want to raise an error when source is not found

--- a/db/migrate/20190306105438_change_policies_progress_record_value_to_text.rb
+++ b/db/migrate/20190306105438_change_policies_progress_record_value_to_text.rb
@@ -1,0 +1,6 @@
+class ChangePoliciesProgressRecordValueToText < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :climate_policy_progress_records, :value, :float
+    add_column :climate_policy_progress_records, :value, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_06_135352) do
+ActiveRecord::Schema.define(version: 2019_03_06_105438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,10 +127,10 @@ ActiveRecord::Schema.define(version: 2019_02_06_135352) do
     t.bigint "indicator_id"
     t.string "axis_x"
     t.string "category"
-    t.float "value", null: false
     t.string "target"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "value"
     t.index ["indicator_id"], name: "index_climate_policy_progress_records_on_indicator_id"
   end
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "eslint-plugin-react": "7.10.0",
     "husky": "0.14.3",
     "lint-staged": "4.1.1",
-    "prettier": "0.11.0",
+    "prettier": "1.16.4",
     "prop-types": "15.5.10",
     "redux-logger": "3.0.6",
     "release": "github:vizzuality/release#4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -555,14 +555,6 @@ ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
-ast-types@0.8.18:
-  version "0.8.18"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.18.tgz#c8b98574898e8914e9d8de74b947564a9fe929af"
-
-"ast-types@git+https://github.com/jlongster/ast-types.git":
-  version "0.9.3"
-  resolved "git+https://github.com/jlongster/ast-types.git#4b373d7e710105b07b22a12389ef2d8e1bcf2412"
-
 async-each@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -658,14 +650,6 @@ axobject-query@^2.0.1:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
   dependencies:
     ast-types-flow "0.0.7"
-
-babel-code-frame@6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
-  dependencies:
-    chalk "^1.1.0"
-    esutils "^2.0.2"
-    js-tokens "^3.0.0"
 
 babel-code-frame@^6.11.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -1455,10 +1439,6 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0, babel-types@^6.26
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
-
 babylon@7.0.0-beta.31:
   version "7.0.0-beta.31"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
@@ -1890,7 +1870,7 @@ chalk@2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.2.0"
 
-chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -2213,7 +2193,7 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
-colors@>=0.6.2, colors@^1.1.2:
+colors@^1.1.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
 
@@ -3508,7 +3488,7 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
-esutils@2.0.2, esutils@^2.0.2:
+esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
@@ -3929,14 +3909,6 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-parser@0.38.0:
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.38.0.tgz#a631c46170c5b42400d905a75cfc83ce8db29424"
-  dependencies:
-    ast-types "0.8.18"
-    colors ">=0.6.2"
-    minimist ">=0.2.0"
-
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -4106,13 +4078,13 @@ get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
 
-get-stdin@5.0.1, get-stdin@^5.0.0, get-stdin@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
-
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+get-stdin@^5.0.0, get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -4202,17 +4174,6 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
-
-glob@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 glob@7.1.2:
   version "7.1.2"
@@ -6193,7 +6154,7 @@ minimist@1.1.x:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
 
-minimist@1.2.0, minimist@>=0.2.0, minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -7822,20 +7783,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-0.11.0.tgz#23bceac71fc7591da393aa341cd237488c51cfe5"
-  dependencies:
-    ast-types "git+https://github.com/jlongster/ast-types.git"
-    babel-code-frame "6.22.0"
-    babylon "6.15.0"
-    esutils "2.0.2"
-    flow-parser "0.38.0"
-    get-stdin "5.0.1"
-    glob "7.1.1"
-    minimist "1.2.0"
-
-prettier@^1.14.3:
+prettier@1.16.4, prettier@^1.14.3:
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
 


### PR DESCRIPTION
Changes in snapshot of progress

- changes in tooltips (moving total from header to separate row and only if there is more than one value)
- text display is actually stored in text now
- missing unit in chart's yAxis (although now it's displaying in 
- `Reporting value` is a indicator name

[PIVOTAL](https://www.pivotaltracker.com/story/show/164367776)

```
bundle exec rake db:migrate
bundle exec rake climate_policies:import
```