### PR TITLE
Upgrade cw-components version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "compression-webpack-plugin": "1.0.0",
     "core-js": "2.5.3",
     "css-loader": "0.28.7",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.41.0",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.42.0",
     "directory-named-webpack-plugin": "4.0.0",
     "dotenv": "4.0.0",
     "es6-promise": "^4.2.4",


### PR DESCRIPTION
This PR updates `cw-components` version to avoid the overlap of yAxis last tick and yAxis units label.
[Pivotal](https://www.pivotaltracker.com/story/show/164532605)

![image](https://user-images.githubusercontent.com/6906348/54267596-cdf11900-4579-11e9-875b-953669e2cb9d.png)
