### PR TITLE
Feature/socioeconomics energy chart tweaks

### DIFF
--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/economy/economy-selectors.js
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/economy/economy-selectors.js
@@ -1,5 +1,5 @@
 import { createStructuredSelector, createSelector } from 'reselect';
-import { format } from 'd3-format';
+import { format, formatSpecifier, precisionFixed } from 'd3-format';
 import sortBy from 'lodash/sortBy';
 import flatten from 'lodash/flatten';
 import uniq from 'lodash/uniq';
@@ -199,6 +199,16 @@ const getNationalBarChartData = createSelector(
 
     const unit = indicator && indicator.unit;
     const theme = getThemeConfig(getYColumn(rawData, CHART_COLORS));
+
+    const formatFunction = formatUnit =>
+      formatUnit === '%'
+        ? value => `${value}%`
+        : value => {
+            const precision = value > 10000 && value < 1000000 ? 0.001 : 0.01;
+            const s = formatSpecifier('s');
+            s.precision = precisionFixed(precision);
+            return format(s)(value).replace('G', 'B');
+          };
     return {
       data: chartXYvalues,
       domain: getDomain(),
@@ -212,8 +222,7 @@ const getNationalBarChartData = createSelector(
           x: { label: 'Year' },
           indicator: unitLabels[unit] ? unitLabels[unit] : unit,
           theme,
-          formatFunction: value =>
-            `${format(',.4s')(`${value}`).replace('G', 'B')}`
+          formatFunction: formatFunction(unit)
         },
         animation: false,
         columns: { x: getXColumn(), y: getYColumn(rawData) },

--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/economy/economy-selectors.js
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/economy/economy-selectors.js
@@ -35,6 +35,17 @@ const getYColumn = data =>
   data.map(d => ({ label: d.label, value: d.category || d.key }));
 
 const unitLabels = { unit: '₹ Billion', million: 'People', '%': 'Percentage' };
+
+const formatFunction = unit =>
+  unit === '%'
+    ? value => `${value}%`
+    : value => {
+        const precision = value > 10000 && value < 1000000 ? 0.001 : 0.01;
+        const s = formatSpecifier('s');
+        s.precision = precisionFixed(precision);
+        return format(s)(value).replace('G', 'B');
+      };
+
 export const getSourceIndicatorCode = createSelector(
   getQuery,
   query =>
@@ -200,15 +211,6 @@ const getNationalBarChartData = createSelector(
     const unit = indicator && indicator.unit;
     const theme = getThemeConfig(getYColumn(rawData, CHART_COLORS));
 
-    const formatFunction = formatUnit =>
-      formatUnit === '%'
-        ? value => `${value}%`
-        : value => {
-            const precision = value > 10000 && value < 1000000 ? 0.001 : 0.01;
-            const s = formatSpecifier('s');
-            s.precision = precisionFixed(precision);
-            return format(s)(value).replace('G', 'B');
-          };
     return {
       data: chartXYvalues,
       domain: getDomain(),

--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/economy/economy-selectors.js
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/economy/economy-selectors.js
@@ -203,7 +203,10 @@ const getNationalBarChartData = createSelector(
       data: chartXYvalues,
       domain: getDomain(),
       config: {
-        axes: getAxes('Years', source === 'GDP' ? 'GDP' : 'Employment'),
+        axes: getAxes(
+          { name: 'Years' },
+          { name: source === 'GDP' ? 'GDP' : 'Employment' }
+        ),
         tooltip: {
           ...getTooltipConfig(getYColumn(rawData)),
           x: { label: 'Year' },

--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-component.jsx
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-component.jsx
@@ -64,27 +64,25 @@ class Population extends PureComponent {
                 downloadUri={downloadURI}
               />
             </div>
-            {
-              chartData &&
-                (
-                  <Chart
-                    type="bar"
-                    loading={loading}
-                    config={chartData.config}
-                    data={chartData.data}
-                    theme={{ legend: styles.legend }}
-                    customTooltip={<CustomTooltip />}
-                    getCustomYLabelFormat={chartData.config.yLabelFormat}
-                    domain={chartData.domain}
-                    dataOptions={chartData.dataOptions}
-                    dataSelected={chartData.dataSelected}
-                    margin={{ bottom: 10 }}
-                    height={300}
-                    barSize={30}
-                    onLegendChange={onLegendChange}
-                  />
-                )
-            }
+            {chartData && (
+              <Chart
+                type="bar"
+                loading={loading}
+                config={chartData.config}
+                data={chartData.data}
+                theme={{ legend: styles.legend }}
+                customTooltip={<CustomTooltip />}
+                getCustomYLabelFormat={chartData.config.yLabelFormat}
+                domain={chartData.domain}
+                dataOptions={chartData.dataOptions}
+                dataSelected={chartData.dataSelected}
+                margin={{ bottom: 10 }}
+                height={300}
+                barSize={30}
+                onLegendChange={onLegendChange}
+                showUnit
+              />
+            )}
           </div>
         </div>
       </div>

--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-selectors.js
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-selectors.js
@@ -245,7 +245,14 @@ const getBarChartData = createSelector(
       data: chartXYvalues,
       domain: getDomain(),
       config: {
-        axes: getAxes('Year', 'People'),
+        axes: getAxes(
+          { name: 'Year' },
+          {
+            name: 'People',
+            unit: unit === 'index' && 'HDI',
+            label: { dx: 28, dy: 10 }
+          }
+        ),
         tooltip: {
           ...getTooltipConfig(getYColumn(rawData)),
           x: { label: 'Year' },

--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/shared/socioeconomic-selectors.js
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/shared/socioeconomic-selectors.js
@@ -3,26 +3,30 @@ import { createSelector } from 'reselect';
 
 const { COUNTRY_ISO } = process.env;
 
-export const getQuery = ({ location }) => location && location.query || null;
+export const getQuery = ({ location }) => (location && location.query) || null;
 
 export const getIndicators = ({ indicators }) => indicators && indicators.data;
 export const getLoading = ({ indicators }) => !indicators;
 
 export const getNationalIndicators = createSelector(
-  [ getIndicators ],
+  [getIndicators],
   indicators => {
     if (!indicators || isEmpty(indicators)) return null;
-    return indicators.values &&
-      indicators.values.filter(ind => ind.location_iso_code3 === COUNTRY_ISO);
+    return (
+      indicators.values &&
+      indicators.values.filter(ind => ind.location_iso_code3 === COUNTRY_ISO)
+    );
   }
 );
 
 export const getProvincesIndicators = createSelector(
-  [ getIndicators ],
+  [getIndicators],
   indicators => {
     if (!indicators || isEmpty(indicators)) return null;
-    return indicators.values &&
-      indicators.values.filter(ind => ind.location_iso_code3 !== COUNTRY_ISO);
+    return (
+      indicators.values &&
+      indicators.values.filter(ind => ind.location_iso_code3 !== COUNTRY_ISO)
+    );
   }
 );
 
@@ -34,24 +38,27 @@ export const getIndicatorsMetadata = createSelector(
   }
 );
 
-export const getIndicatorsValues = createSelector(getIndicators, indicators => {
-  if (!indicators || isEmpty(indicators)) return null;
-  return indicators.values;
-});
+export const getIndicatorsValues = createSelector(
+  getIndicators,
+  indicators => {
+    if (!indicators || isEmpty(indicators)) return null;
+    return indicators.values;
+  }
+);
 
 export const getFirstChartFilter = (queryName, selectedOptions) => {
   const label = selectedOptions[queryName] && selectedOptions[queryName].label;
 
-  return [ { label } ];
+  return [{ label }];
 };
 
-export const getDomain = () => ({ x: [ 'auto', 'auto' ], y: [ 0, 'auto' ] });
+export const getDomain = () => ({ x: ['auto', 'auto'], y: [0, 'auto'] });
 
-export const getAxes = (xName, yName) => ({
-  xBottom: { name: xName, unit: '', format: 'string' },
-  yLeft: { name: yName, unit: '', format: 'number' }
+export const getAxes = (xBottom, yLeft) => ({
+  xBottom: { unit: '', format: 'string', ...xBottom },
+  yLeft: { unit: '', format: 'number', ...yLeft }
 });
 
-export const getXColumn = () => [ { label: 'year', value: 'x' } ];
+export const getXColumn = () => [{ label: 'year', value: 'x' }];
 
 export const getTheme = color => ({ y: { stroke: color, fill: color } });


### PR DESCRIPTION
This PR: 
- shows unit on y axis in `Population > HDI` chart: [PIVOTAL](https://www.pivotaltracker.com/story/show/164902318) | [BASECAMP](https://basecamp.com/1756858/projects/15229632/todos/383855275)
![Screenshot from 2019-04-01 18 19 13](https://user-images.githubusercontent.com/15097138/55346537-ab805a80-54aa-11e9-8aa0-ce2005ebf2fc.png)

- changes numbers of decimals to maximum one  (tooltip in `Economic profile` chart) 
[PIVOTAL](https://www.pivotaltracker.com/story/show/164902335) | [BASECAMP](https://basecamp.com/1756858/projects/15229632/todos/383859923)