### PR TITLE
Feature/country context charts tweaks

### DIFF
--- a/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
+++ b/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
@@ -17,12 +17,14 @@ const getFilteredPolicies = createSelector(
     const filtersFieldsArray = Object.keys(query).filter(
       f => !isEmpty(query[f])
     );
-    return policies.reduce((acc, policy) => {
-      const notFiltered = filtersFieldsArray.find(f =>
-        castArray(query[f]).some(q =>
-          policy[f].toLowerCase().includes(q.toLowerCase())));
-      return notFiltered ? [...acc, policy] : [...acc];
+    const x = policies.reduce((acc, policy) => {
+      const notFiltered = filtersFieldsArray.filter(f =>
+        castArray(query[f]).some(q => policy[f].toLowerCase().includes(q.toLowerCase())));
+      const fullyMatch = filtersFieldsArray.every(filter =>
+        notFiltered.includes(filter));
+      return fullyMatch ? [...acc, policy] : [...acc];
     }, []);
+    return x;
   }
 );
 

--- a/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
+++ b/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
@@ -10,22 +10,19 @@ import {
 const getQuery = ({ location }) => location && (location.query || null);
 
 const getFilteredPolicies = createSelector(
-  [ getQuery, getClimatePoliciesList ],
+  [getQuery, getClimatePoliciesList],
   (query, policies) => {
     if (!policies || isEmpty(policies)) return null;
     if (!query || isEmpty(query)) return policies;
-    const filtersFieldsArray = Object
-      .keys(query)
-      .filter(f => !isEmpty(query[f]));
-    return policies.reduce(
-      (acc, policy) => {
-        const notFiltered = filtersFieldsArray.find(
-          f => castArray(query[f]).some(q => policy[f].includes(q))
-        );
-        return notFiltered ? [ ...acc, policy ] : [ ...acc ];
-      },
-      []
+    const filtersFieldsArray = Object.keys(query).filter(
+      f => !isEmpty(query[f])
     );
+    return policies.reduce((acc, policy) => {
+      const notFiltered = filtersFieldsArray.find(f =>
+        castArray(query[f]).some(q =>
+          policy[f].toLowerCase().includes(q.toLowerCase())));
+      return notFiltered ? [...acc, policy] : [...acc];
+    }, []);
   }
 );
 
@@ -37,16 +34,19 @@ const getFilteredPoliciesBySector = createSelector(
   }
 );
 
-const getKeyClimatePolicies = createSelector(getFilteredPolicies, policies => {
-  if (!policies) return null;
-  return policies
-    .filter(({ key_policy }) => key_policy)
-    .map(({ title, status, progress }) => ({
-      policy: title,
-      policy_status: status,
-      policy_progress: progress
-    }));
-});
+const getKeyClimatePolicies = createSelector(
+  getFilteredPolicies,
+  policies => {
+    if (!policies) return null;
+    return policies
+      .filter(({ key_policy }) => key_policy)
+      .map(({ title, status, progress }) => ({
+        policy: title,
+        policy_status: status,
+        policy_progress: progress
+      }));
+  }
+);
 
 export const climatePolicies = createStructuredSelector({
   query: getQuery,

--- a/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
+++ b/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
@@ -17,14 +17,14 @@ const getFilteredPolicies = createSelector(
     const filtersFieldsArray = Object.keys(query).filter(
       f => !isEmpty(query[f])
     );
-    const x = policies.reduce((acc, policy) => {
+    return policies.reduce((acc, policy) => {
       const notFiltered = filtersFieldsArray.filter(f =>
-        castArray(query[f]).some(q => policy[f].toLowerCase().includes(q.toLowerCase())));
+        castArray(query[f]).some(q =>
+          policy[f].toLowerCase().includes(q.toLowerCase())));
       const fullyMatch = filtersFieldsArray.every(filter =>
         notFiltered.includes(filter));
       return fullyMatch ? [...acc, policy] : [...acc];
     }, []);
-    return x;
   }
 );
 

--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-component.jsx
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-component.jsx
@@ -76,7 +76,7 @@ class Population extends PureComponent {
                 domain={chartData.domain}
                 dataOptions={chartData.dataOptions}
                 dataSelected={chartData.dataSelected}
-                margin={{ bottom: 10 }}
+                margin={{ top: 20, bottom: 10 }}
                 height={300}
                 barSize={30}
                 onLegendChange={onLegendChange}

--- a/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-selectors.js
+++ b/app/javascript/app/pages/country-context/socioeconomic-indicators/population/population-selectors.js
@@ -215,6 +215,26 @@ const getChartXYvalues = createSelector(
   }
 );
 
+const getYAxisUnit = unit => {
+  switch (unit) {
+    case 'index':
+      return {
+        unit: 'HDI',
+        label: { dx: 28, dy: 24 }
+      };
+    case 'million':
+      return {
+        unit: 'People',
+        label: { dx: 14, dy: 24 }
+      };
+    default:
+      return {
+        unit: upperFirst(unit),
+        label: { dx: 14, dy: 10 }
+      };
+  }
+};
+
 const getBarChartData = createSelector(
   [
     getIndicators,
@@ -249,8 +269,7 @@ const getBarChartData = createSelector(
           { name: 'Year' },
           {
             name: 'People',
-            unit: unit === 'index' && 'HDI',
-            label: { dx: 28, dy: 10 }
+            ...getYAxisUnit(unit)
           }
         ),
         tooltip: {

--- a/app/javascript/app/selectors/climate-policies-selectors.js
+++ b/app/javascript/app/selectors/climate-policies-selectors.js
@@ -103,7 +103,11 @@ export const getResponsibleAuthorities = createSelector(
     if (!list) return null;
 
     return uniq(
-      flatMap(list, p => (p.authority || '').split(',').map(a => a.trim()))
+      flatMap(list, p =>
+        (p.authority || '')
+          .replace(', and', ',')
+          .split(',')
+          .map(a => a.trim()))
     ).sort();
   }
 );


### PR DESCRIPTION
This PR fixes few issues from feedback:

- Add unit labels on y-axis to Population charts in Country context:
[PIVOTAL](https://www.pivotaltracker.com/story/show/165032033) | [BASECAMP](https://basecamp.com/1756858/projects/15229632/todos/383884080)

- Fix broken logic for search in Climate Policies:
[PIVOTAL](https://www.pivotaltracker.com/story/show/165032057) | [BASECAMP](https://basecamp.com/1756858/projects/15229632/todos/384127374)
![m2uqm-q5pku](https://user-images.githubusercontent.com/15097138/55555965-54fb6200-56de-11e9-88a8-e056ebe4d57e.gif)