### PR TITLE
Feature/climate policies feedback

### DIFF
--- a/app/javascript/app/components/footer/footer-component.jsx
+++ b/app/javascript/app/components/footer/footer-component.jsx
@@ -23,9 +23,7 @@ const upperFooter = (
     <div className={styles.line} />
     <div className={styles.grid}>
       <div className={styles.content}>
-        <span className={styles.text}>
-          Funding for this initiative is provided by
-        </span>
+        <span className={styles.text}>Supported by:</span>
         {founders.map(
           partner =>
             partner.img && (

--- a/app/javascript/app/components/footer/footer-styles.scss
+++ b/app/javascript/app/components/footer/footer-styles.scss
@@ -68,7 +68,7 @@
   .text {
     font-size: $font-size;
     background-color: $white;
-    width: 275px;
+    width: max-content;
   }
 }
 

--- a/app/javascript/app/constants/founders.js
+++ b/app/javascript/app/constants/founders.js
@@ -2,9 +2,9 @@ import fmencbnsImage from 'assets/fmencbns';
 
 export default [
   {
-    link: 'http://www.bmub.bund.de/en/',
+    link: 'http://www.international-climate-initiative.com/en',
     orderingString: 'FMENCBNS',
     img: { alt: 'FMENCBNS', src: fmencbnsImage, customClass: 'BMULogo' },
-    description: 'This initiative is a part of the International Climate Initiative (IKI).'
+    description: 'Based on a decision of the German Bundestag'
   }
 ];

--- a/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-component.jsx
+++ b/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-component.jsx
@@ -13,19 +13,18 @@ const SEARCHBOX_TABS = [
   { slug: 'authority', name: 'Responsible Authority' }
 ];
 
-const ClimatePolicies = (
-  {
-    policiesListBySector,
-    sectors,
-    authorities,
-    onSearchChange,
-    onCheckboxChange,
-    handleTagRemove,
-    handleAllTagsRemove,
-    t,
-    keyPoliciesList
-  }
-) => (
+const ClimatePolicies = ({
+  policiesListBySector,
+  sectors,
+  authorities,
+  onSearchChange,
+  onCheckboxChange,
+  handleTagRemove,
+  handleAllTagsRemove,
+  t,
+  keyPoliciesList,
+  titleLinks
+}) => (
   <div>
     <section className={styles.pageIntro}>
       <div className={styles.pageLayout}>
@@ -62,59 +61,49 @@ const ClimatePolicies = (
         </div>
       </section>
       <section className={styles.policyTypeSectionWrapper}>
-        {
-          !isEmpty(policiesListBySector)
-            ? Object.keys(policiesListBySector).map(sector => (
-              <section className={styles.policyTypeSection} key={sector}>
-                <h3 className={styles.title}>{sector}</h3>
-                <div className={styles.policiesCardsContainer}>
-                  {policiesListBySector[sector].map(policy => (
-                    <PoliciesCard
-                      key={policy.title}
-                      title={policy.title}
-                      description={policy.description}
-                      responsibleAuthority={policy.authority}
-                      action={{
-                        type: 'location/CLIMATE_POLICY_DETAIL',
-                        payload: {
-                          policy: policy.code,
-                          section: 'overview',
-                          data: policy
-                        }
-                      }}
-                    />
-                  ))}
-                </div>
-              </section>
-            ))
-            : (
-              <NoContent
-                minHeight={300}
-                message="No data found with this search"
-              />
-)
-        }
+        {!isEmpty(policiesListBySector) ? (
+          Object.keys(policiesListBySector).map(sector => (
+            <section className={styles.policyTypeSection} key={sector}>
+              <h3 className={styles.title}>{sector}</h3>
+              <div className={styles.policiesCardsContainer}>
+                {policiesListBySector[sector].map(policy => (
+                  <PoliciesCard
+                    key={policy.title}
+                    title={policy.title}
+                    description={policy.description}
+                    responsibleAuthority={policy.authority}
+                    action={{
+                      type: 'location/CLIMATE_POLICY_DETAIL',
+                      payload: {
+                        policy: policy.code,
+                        section: 'overview',
+                        data: policy
+                      }
+                    }}
+                  />
+                ))}
+              </div>
+            </section>
+          ))
+        ) : (
+          <NoContent minHeight={300} message="No data found with this search" />
+        )}
       </section>
-      {
-        !isEmpty(keyPoliciesList) && (
+      {!isEmpty(keyPoliciesList) && (
         <section className={styles.policyKeyListWrapper}>
           <h2 className={styles.title}>
             {t('pages.climate-policies.key-policies-header')}
           </h2>
           <Table
             data={keyPoliciesList}
-            defaultColumns={[
-                  'policy',
-                  'policy_status',
-                  'policy_progress'
-                ]}
+            defaultColumns={['policy', 'policy_status', 'policy_progress']}
             setColumnWidth={() => 370}
             tableHeight={600}
             dynamicRowsHeight
+            titleLinks={titleLinks}
           />
         </section>
-          )
-      }
+      )}
       <ClimatePoliciesProvider />
     </div>
   </div>
@@ -129,14 +118,16 @@ ClimatePolicies.propTypes = {
   handleTagRemove: PropTypes.func.isRequired,
   handleAllTagsRemove: PropTypes.func.isRequired,
   onCheckboxChange: PropTypes.func.isRequired,
-  keyPoliciesList: PropTypes.arrayOf(PropTypes.shape({}))
+  keyPoliciesList: PropTypes.arrayOf(PropTypes.shape({})),
+  titleLinks: PropTypes.arrayOf(PropTypes.shape({}))
 };
 
 ClimatePolicies.defaultProps = {
   policiesListBySector: {},
   sectors: null,
   authorities: null,
-  keyPoliciesList: null
+  keyPoliciesList: null,
+  titleLinks: null
 };
 
 export default ClimatePolicies;

--- a/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
+++ b/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-selectors.js
@@ -42,11 +42,29 @@ const getKeyClimatePolicies = createSelector(
     if (!policies) return null;
     return policies
       .filter(({ key_policy }) => key_policy)
-      .map(({ title, status, progress }) => ({
-        policy: title,
+      .map(({ title, status, progress, code }) => ({
+        policy: {
+          label: title,
+          name: title,
+          code
+        },
         policy_status: status,
         policy_progress: progress
       }));
+  }
+);
+
+const getTitleLinks = createSelector(
+  [getKeyClimatePolicies],
+  data => {
+    if (!data || !data.length) return null;
+    return data.map(p => [
+      {
+        columnName: 'policy',
+        url: `/climate-policies/${p.policy.code}/overview`,
+        label: p.label
+      }
+    ]);
   }
 );
 
@@ -56,5 +74,6 @@ export const climatePolicies = createStructuredSelector({
   policiesListBySector: getFilteredPoliciesBySector,
   sectors: getSectors,
   authorities: getResponsibleAuthorities,
-  keyPoliciesList: getKeyClimatePolicies
+  keyPoliciesList: getKeyClimatePolicies,
+  titleLinks: getTitleLinks
 });

--- a/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-styles.scss
+++ b/app/javascript/app/pages/climate-policies/climate-policy-module/climate-policy-module-styles.scss
@@ -120,4 +120,11 @@
     color: $downriver;
     font-size: $font-size-x-large;
   }
+
+  a {
+    line-height: $line-height !important;
+    color: $elephant-blue !important;
+    border-bottom: 0 !important;
+    text-decoration: underline !important;
+  }
 }

--- a/app/javascript/app/pages/climate-policies/instruments/instruments-component.jsx
+++ b/app/javascript/app/pages/climate-policies/instruments/instruments-component.jsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown from 'react-markdown/with-html';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import DateTime from 'luxon/src/datetime';
@@ -51,10 +51,9 @@ const table = (instrument, sources) => (
               {columnNames[column]}
             </td>
             <td className={cx(styles.cell)}>
-              {
-                instrument[column] &&
-                  <ReactMarkdown source={instrument[column]} />
-              }
+              {instrument[column] && (
+                <ReactMarkdown source={instrument[column]} escapeHtml={false} />
+              )}
             </td>
           </tr>
         ))}
@@ -81,26 +80,22 @@ class Instruments extends PureComponent {
     return (
       <div className={styles.page}>
         <div className={styles.titleContainer}>
-          <div className={styles.title}>
-            Policy Instruments
-          </div>
+          <div className={styles.title}>Policy Instruments</div>
         </div>
-        {
-          instruments && instruments && (
+        {instruments && (
           <Accordion
             loading={false}
             data={instruments}
             openSlug={openSlug}
             handleOnClick={this.handleAccordionOnClick}
             theme={{
-                  title: styles.accordionTitle,
-                  header: styles.accordionHeader
-                }}
+              title: styles.accordionTitle,
+              header: styles.accordionHeader
+            }}
           >
             {instruments.map(instrument => table(instrument, sources))}
           </Accordion>
-            )
-        }
+        )}
         <ClimatePolicyProvider params={{ policyCode }} />
       </div>
     );


### PR DESCRIPTION
This PR adds a few fixes for the climate policies page:

- change BMU logo, according to the RP guidance
[PIVOTAL](https://www.pivotaltracker.com/story/show/165032004)
![Screenshot from 2019-04-04 17 24 09](https://user-images.githubusercontent.com/15097138/55572162-ea0e5300-56fe-11e9-8c7f-64da1544fe86.png)


- link policies on the table to policy overview page:
[PIVOTAL](https://www.pivotaltracker.com/story/show/165120185)
![Screenshot from 2019-04-04 17 24 54](https://user-images.githubusercontent.com/15097138/55572272-25108680-56ff-11e9-9530-20824f1cc967.png)

- add html parsing to description fields in `Climate Policies/Instruments`:
[PIVOTAL](https://www.pivotaltracker.com/story/show/165120207) (it's a part of this task, but it's not complete)
![Screenshot from 2019-04-04 17 35 16](https://user-images.githubusercontent.com/15097138/55572683-0a8add00-5700-11e9-8bc2-56ada2a3503b.png)
