### PR TITLE
Feature/enable html parsing in climate policies

### DIFF
--- a/app/javascript/app/pages/climate-policies/indicators/indicators-component.jsx
+++ b/app/javascript/app/pages/climate-policies/indicators/indicators-component.jsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown from 'react-markdown/with-html';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import isEmpty from 'lodash/isEmpty';
@@ -21,24 +21,29 @@ const columnNames = {
 };
 
 const columnValueRenderers = {
-  source_ids: (sourceIds, sources) => sourceIds.map(sourceId => {
-    const source = sources && sources.find(s => s.id === sourceId);
-    return source && (
-    <div key={source.code}>
-      <a
-        href={source.link}
-        alt={source.code}
-        className={styles.link}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {source.code}
-      </a>
-    </div>
+  source_ids: (sourceIds, sources) =>
+    sourceIds.map(sourceId => {
+      const source = sources && sources.find(s => s.id === sourceId);
+      return (
+        source && (
+          <div key={source.code}>
+            <a
+              href={source.link}
+              alt={source.code}
+              className={styles.link}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {source.code}
+            </a>
+          </div>
+        )
       );
-  })
+    })
 };
-const columnValueDefaultRenderer = value => <ReactMarkdown source={value} />;
+const columnValueDefaultRenderer = value => (
+  <ReactMarkdown source={value} escapeHtml={false} />
+);
 
 const renderColumnValue = (indicator, column, sources) => {
   const isSourcesColumn = column === 'source_ids';
@@ -108,9 +113,8 @@ class Indicators extends PureComponent {
   handleSecondAccordionOnClick = slug => {
     const { openSecondLevelAccordionSlug } = this.state;
     this.setState({
-      openSecondLevelAccordionSlug: openSecondLevelAccordionSlug === slug
-        ? 'none'
-        : slug
+      openSecondLevelAccordionSlug:
+        openSecondLevelAccordionSlug === slug ? 'none' : slug
     });
   };
 
@@ -121,21 +125,18 @@ class Indicators extends PureComponent {
     return (
       <div className={styles.page}>
         <div className={styles.titleContainer}>
-          <div className={styles.title}>
-            Indicators
-          </div>
+          <div className={styles.title}>Indicators</div>
         </div>
-        {
-          indicators && (
+        {indicators && (
           <Accordion
             loading={false}
             data={indicators}
             openSlug={openSlug}
             handleOnClick={this.handleAccordionOnClick}
             theme={{
-                  title: styles.accordionTitle,
-                  header: styles.accordionHeader
-                }}
+              title: styles.accordionTitle,
+              header: styles.accordionHeader
+            }}
           >
             {indicators.map(({ content }) => (
               <Accordion
@@ -144,16 +145,15 @@ class Indicators extends PureComponent {
                 openSlug={openSecondLevelAccordionSlug}
                 handleOnClick={this.handleSecondAccordionOnClick}
                 theme={{
-                      title: styles.secondAccordionTitle,
-                      header: styles.secondAccordionHeader
-                    }}
+                  title: styles.secondAccordionTitle,
+                  header: styles.secondAccordionHeader
+                }}
               >
                 {content.map(ind => table(ind, sources))}
               </Accordion>
-                ))}
+            ))}
           </Accordion>
-            )
-        }
+        )}
         <ClimatePolicyProvider params={{ policyCode }} />
       </div>
     );

--- a/app/javascript/app/pages/climate-policies/overview/overview-component.jsx
+++ b/app/javascript/app/pages/climate-policies/overview/overview-component.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown from 'react-markdown/with-html';
 import PropTypes from 'prop-types';
 import ClimatePoliciesProvider from 'providers/climate-policies-provider';
 import InfoButton from 'components/info-button';
@@ -15,32 +15,26 @@ const Overview = ({ policiesByCode, policyCode }) => (
         <div className={styles.title}>
           <span>Description</span>
         </div>
-        {
-          policiesByCode &&
-            policiesByCode[policyCode] &&
-            (
-              <ReactMarkdown
-                className={styles.description}
-                source={policiesByCode[policyCode].description}
-              />
-            )
-        }
+        {policiesByCode && policiesByCode[policyCode] && (
+          <ReactMarkdown
+            className={styles.description}
+            source={policiesByCode[policyCode].description}
+            escapeHtml={false}
+          />
+        )}
       </div>
       <div className={styles.column}>
         <div className={styles.title}>
           <span>Monitoring</span>
           {renderInfoIcon()}
         </div>
-        {
-          policiesByCode &&
-            policiesByCode[policyCode] &&
-            (
-              <ReactMarkdown
-                className={styles.description}
-                source={policiesByCode[policyCode].tracking_description}
-              />
-            )
-        }
+        {policiesByCode && policiesByCode[policyCode] && (
+          <ReactMarkdown
+            className={styles.description}
+            source={policiesByCode[policyCode].tracking_description}
+            escapeHtml={false}
+          />
+        )}
       </div>
     </div>
     <ClimatePoliciesProvider />

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "compression-webpack-plugin": "1.0.0",
     "core-js": "2.5.3",
     "css-loader": "0.28.7",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.44.0",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.49.0",
     "directory-named-webpack-plugin": "4.0.0",
     "dotenv": "4.0.0",
     "es6-promise": "^4.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2655,9 +2655,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.44.0":
-  version "1.44.0"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/ae250b6d2d1cb7eb92b69e30d7b36c573b29b546"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.49.0":
+  version "1.49.0"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/79be039d732d3bc5d8aae54f5f72b53968f4f62c"
   dependencies:
     "@d3fc/d3fc-discontinuous-scale" "^3.0.7"
     "@latticejs/recharts-sunburst" "^1.0.1-beta.0"


### PR DESCRIPTION
This PR enables HTML parsing for Overview, Instruments and Indicators sections in Climate Policies.
**NOTE:** CW Componets has been updated to version 1.49, so before start run `yarn install`
[PIVOTAL](https://www.pivotaltracker.com/story/show/165120207)