### PR TITLE
Fix/climate policies feedback

### DIFF
--- a/app/javascript/app/pages/climate-policies/milestones/milestones-component.jsx
+++ b/app/javascript/app/pages/climate-policies/milestones/milestones-component.jsx
@@ -18,7 +18,7 @@ import styles from './milestones-styles';
 
 const ICONS = { attained, issued, estimated, launched };
 
-const formatDate = date => DateTime.fromISO(date).toFormat('MMMM yyyy');
+const formatDate = date => DateTime.fromISO(date).toFormat('yyyy');
 
 const table = milestones => (
   <table className={styles.table}>
@@ -44,15 +44,9 @@ const table = milestones => (
               <p>{capitalize(milestone.status)}</p>
             </TabletPortraitOnly>
             <p>{formatDate(milestone.date)}</p>
-            {
-              milestone.name &&
-                (
-                  <ReactMarkdown
-                    className={styles.name}
-                    source={milestone.name}
-                  />
-                )
-            }
+            {milestone.name && (
+              <ReactMarkdown className={styles.name} source={milestone.name} />
+            )}
             <p>{milestone.responsible_authority}</p>
             <a href={milestone.data_source_link}>Data source</a>
           </td>
@@ -69,9 +63,7 @@ class Milestones extends PureComponent {
     return (
       <div className={styles.page}>
         <div className={styles.titleContainer}>
-          <div className={styles.title}>
-            Milestones
-          </div>
+          <div className={styles.title}>Milestones</div>
         </div>
         {milestones && table(milestones)}
         <ClimatePolicyProvider params={{ policyCode }} />

--- a/app/javascript/app/selectors/climate-policies-selectors.js
+++ b/app/javascript/app/selectors/climate-policies-selectors.js
@@ -51,7 +51,7 @@ export const getInstruments = createSelector(
   [getClimatePolicyDetails],
   policyDetails => {
     if (!policyDetails) return null;
-    const instruments = policyDetails && policyDetails.instruments;
+    const instruments = policyDetails && policyDetails.instruments.reverse();
     return instruments.map(instrument => ({
       ...instrument,
       slug: instrument.title


### PR DESCRIPTION
This PR solves two issues on Climate Policies page:

1. Order of elements in Instruments section now should be consistent with CSV files
[BASECAMP 1](https://basecamp.com/1756858/projects/15229632/todos/384785382) | [BASECAMP 2](https://basecamp.com/1756858/projects/15229632/todos/384889973) | [PIVOTAL](https://www.pivotaltracker.com/story/show/165240638)

2. Remove month from date in Milestons timeline
[BASECAMP](https://basecamp.com/1756858/projects/15229632/todos/384811319) | [PIVOTAL](https://www.pivotaltracker.com/story/show/165183143)