### PR TITLE
enable using local cw-components on development

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -2,11 +2,19 @@
 
 // eslint-disable-next-line
 const dotenv = require('dotenv').config();
+const path = require('path');
 const merge = require('webpack-merge');
 const sharedConfig = require('./shared.js');
 const { settings, output } = require('./configuration.js');
 
 module.exports = merge(sharedConfig, {
+  resolve: {
+    symlinks: false,
+    alias: {
+      react: path.resolve('./node_modules/react'),
+      'react-dom': path.resolve('./node_modules/react-dom')
+    }
+  },
   devtool: '#eval-source-map',
   mode: 'development',
   stats: { errorDetails: true },
@@ -21,6 +29,8 @@ module.exports = merge(sharedConfig, {
     compress: true,
     headers: { 'Access-Control-Allow-Origin': '*' },
     historyApiFallback: true,
-    watchOptions: { ignored: /node_modules/ }
+    watchOptions: {
+      ignored: /node_modules([\\]+|\/)+(?!cw-components)/
+    }
   }
 });


### PR DESCRIPTION
This should fix the error that occurs when trying to use the local version of cw-components following using yarn link.