### PR TITLE
Add Sources row to instruments table

### DIFF
--- a/app/javascript/app/components/info-button/info-button-component.jsx
+++ b/app/javascript/app/components/info-button/info-button-component.jsx
@@ -22,7 +22,10 @@ class InfoButton extends PureComponent {
     const { className, theme, dark, infoModalData } = this.props;
     return (
       <div className={className}>
-        <div data-for="blueTooltip" data-tip="Information">
+        <div
+          data-for="blueTooltip"
+          data-tip={(infoModalData && infoModalData.title) || 'Information'}
+        >
           <Icon
             alt="info"
             icon={dark ? darkInfo : iconInfo}
@@ -49,7 +52,7 @@ InfoButton.propTypes = {
   className: PropTypes.object,
   theme: PropTypes.shape({ icon: PropTypes.string }),
   dark: PropTypes.bool,
-  slugs: PropTypes.oneOfType([ PropTypes.string, PropTypes.array ]),
+  slugs: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   setModalMetadata: PropTypes.func.isRequired,
   infoModalData: PropTypes.shape({
     data: PropTypes.array,

--- a/app/javascript/app/pages/climate-policies/instruments/instruments-styles.scss
+++ b/app/javascript/app/pages/climate-policies/instruments/instruments-styles.scss
@@ -64,7 +64,9 @@
 
 .link {
   text-decoration: underline;
-  color: $dark-blue;
+  color: $elephant-blue;
+  cursor: pointer;
+  font-size: $font-size;
 }
 
 .document {


### PR DESCRIPTION
This PR adds `Sources:` row with links to `Climate Policies/Instruments` and changes the text of info tooltip to `Sources`.
[PIVOTAL](https://www.pivotaltracker.com/story/show/165536050) | [BASECAMP - part of the thread](https://basecamp.com/1756858/projects/15229632/todos/384785795#comment_694030926)
![30if1-r8hhb](https://user-images.githubusercontent.com/15097138/56591627-f7717b80-65e0-11e9-95fa-1994155191e5.gif)
