### PR TITLE
Feature/policies snapshot enable info buttons

### DIFF
--- a/app/javascript/app/components/info-button/info-button-component.jsx
+++ b/app/javascript/app/components/info-button/info-button-component.jsx
@@ -5,21 +5,28 @@ import { Icon } from 'cw-components';
 import iconInfo from 'assets/icons/info';
 import darkInfo from 'assets/icons/info-fill';
 import ReactTooltip from 'react-tooltip';
-import ModalMetadata from 'components/modal-metadata';
+import ModalMetadata from 'components/modal-metadata/modal-metadata-component';
 import { handleAnalytics } from 'utils/analytics';
 import styles from './info-button-styles.scss';
 
 class InfoButton extends PureComponent {
+  constructor() {
+    super();
+    this.state = { isOpen: false };
+  }
+
   handleInfoClick = () => {
-    const { slugs, setModalMetadata, infoModalData } = this.props;
-    if (slugs || infoModalData) {
-      handleAnalytics('Info Window', 'Open', slugs);
-      setModalMetadata({ slugs, open: true, customTitle: 'Sources' });
+    const { infoModalData } = this.props;
+    if (infoModalData) {
+      this.setState({ isOpen: !this.setState.isOpen });
+      const slugString = infoModalData.tabTitles.join(',');
+      handleAnalytics('Info Window', 'Open', slugString);
     }
   };
 
   render() {
     const { className, theme, dark, infoModalData } = this.props;
+    const { isOpen } = this.state;
     return (
       <div className={className}>
         <div
@@ -38,11 +45,15 @@ class InfoButton extends PureComponent {
           effect="solid"
           className="global_INDTooltip"
         />
-        <ModalMetadata
-          data={infoModalData && infoModalData.data}
-          title={infoModalData && infoModalData.title}
-          tabTitles={infoModalData && infoModalData.tabTitles}
-        />
+        {isOpen && (
+          <ModalMetadata
+            isOpen={isOpen}
+            data={infoModalData && infoModalData.data}
+            title={infoModalData && infoModalData.title}
+            tabTitles={infoModalData && infoModalData.tabTitles}
+            onRequestClose={() => this.setState({ isOpen: false })}
+          />
+        )}
       </div>
     );
   }
@@ -52,8 +63,6 @@ InfoButton.propTypes = {
   className: PropTypes.object,
   theme: PropTypes.shape({ icon: PropTypes.string }),
   dark: PropTypes.bool,
-  slugs: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
-  setModalMetadata: PropTypes.func.isRequired,
   infoModalData: PropTypes.shape({
     data: PropTypes.array,
     title: PropTypes.string,
@@ -63,7 +72,6 @@ InfoButton.propTypes = {
 
 InfoButton.defaultProps = {
   className: {},
-  slugs: null,
   theme: {},
   dark: false,
   infoModalData: undefined

--- a/app/javascript/app/components/info-button/info-button-component.jsx
+++ b/app/javascript/app/components/info-button/info-button-component.jsx
@@ -14,7 +14,7 @@ class InfoButton extends PureComponent {
     const { slugs, setModalMetadata, infoModalData } = this.props;
     if (slugs || infoModalData) {
       handleAnalytics('Info Window', 'Open', slugs);
-      setModalMetadata({ slugs, open: true });
+      setModalMetadata({ slugs, open: true, customTitle: 'Sources' });
     }
   };
 

--- a/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
@@ -41,22 +41,19 @@ class ModalMetadata extends PureComponent {
   render() {
     const { selectedIndex } = this.state;
     const { isOpen, title, tabTitles } = this.props;
-
     return (
       <Modal
         onRequestClose={this.handleOnRequestClose}
         isOpen={isOpen}
-        header={
-          (
-            <ModalHeader
-              tabSelectedIndex={selectedIndex}
-              handleTabIndexChange={this.handleTabIndexChange}
-              tabTitles={tabTitles}
-              title={title}
-              theme={{ header: styles.modalHeaderTitle }}
-            />
-          )
-        }
+        header={(
+          <ModalHeader
+            tabSelectedIndex={selectedIndex}
+            handleTabIndexChange={this.handleTabIndexChange}
+            tabTitles={tabTitles}
+            title={title}
+            theme={{ header: styles.modalHeaderTitle }}
+          />
+)}
       >
         {this.getContent()}
       </Modal>

--- a/app/javascript/app/pages/climate-policies/progress/chart-display/chart-display-component.jsx
+++ b/app/javascript/app/pages/climate-policies/progress/chart-display/chart-display-component.jsx
@@ -15,7 +15,9 @@ class ChartDisplay extends PureComponent {
     const { onFilterChange, indicator } = this.props;
 
     const filter = `${indicator.code}_category`;
-    const values = isArray(selected) ? selected.map(v => v.value).join(',') : selected.value;
+    const values = isArray(selected)
+      ? selected.map(v => v.value).join(',')
+      : selected.value;
 
     onFilterChange({ [filter]: values });
   };
@@ -33,8 +35,10 @@ class ChartDisplay extends PureComponent {
         <div className={styles.chartProgress}>
           <div className={styles.indicatorTitle}>{indicator.title}</div>
           <div className={styles.lastUpdate}>
-            <span className={styles.date}>Last update: {formatDate(indicator.updated_at)}</span>
-            <InfoButton dark slugs="" />
+            <span className={styles.date}>
+              Last update: {formatDate(indicator.updated_at)}
+            </span>
+            <InfoButton dark slugs="" infoModalData={indicator.infoModalData} />
           </div>
         </div>
         <div className={styles.chartContainer}>

--- a/app/javascript/app/pages/climate-policies/progress/progress-bar-display/progress-bar-display-component.jsx
+++ b/app/javascript/app/pages/climate-policies/progress/progress-bar-display/progress-bar-display-component.jsx
@@ -10,17 +10,15 @@ import styles from './progress-bar-display-styles';
 class ProgressBarDisplay extends PureComponent {
   renderProgress = record => {
     const { indicator } = this.props;
-    const progressPercentage = record.value / record.target * 100;
+    const progressPercentage = (record.value / record.target) * 100;
     const key = `${record.indicator_code}_${record.axis_x}`;
 
     return (
       <div key={key}>
         <div className={styles.progressText}>
-          {
-            `${record.value} ${indicator.unit} out of ${record.target} (${progressPercentage.toFixed(
-              0
-            )}%)`
-          }
+          {`${record.value} ${indicator.unit} out of ${
+            record.target
+          } (${progressPercentage.toFixed(0)}%)`}
         </div>
         <ProgressBar progress={progressPercentage} />
       </div>
@@ -32,17 +30,13 @@ class ProgressBarDisplay extends PureComponent {
 
     return (
       <div className={styles.barProgress}>
-        <div className={styles.indicatorTitle}>
-          {indicator.title}
-        </div>
-        <div>
-          {indicator.progress_records.map(this.renderProgress)}
-        </div>
+        <div className={styles.indicatorTitle}>{indicator.title}</div>
+        <div>{indicator.progress_records.map(this.renderProgress)}</div>
         <div className={styles.lastUpdate}>
           <span className={styles.date}>
             Last update: {formatDate(indicator.updated_at)}
           </span>
-          <InfoButton dark slugs="" />
+          <InfoButton dark infoModalData={indicator.infoModalData} />
         </div>
       </div>
     );

--- a/app/javascript/app/pages/climate-policies/progress/text-display/text-display-component.jsx
+++ b/app/javascript/app/pages/climate-policies/progress/text-display/text-display-component.jsx
@@ -7,34 +7,24 @@ import InfoButton from 'components/info-button';
 
 import styles from './text-display-styles';
 
-const TextDisplay = ({ indicator }) => {
-  const tabTitles =
-    indicator && indicator.sources && indicator.sources.map(({ code }) => code);
-  const infoModalData = {
-    data: indicator ? indicator.sources : [],
-    title: 'Sources',
-    tabTitles
-  };
-
-  return (
-    <div className={styles.textProgress}>
-      <div className={styles.indicatorTitle}>{indicator.title}</div>
-      <ul>
-        {indicator.progress_records.map(progress => (
-          <li key={progress.value}>
-            <ReactMarkdown source={progress.value} escapeHtml={false} />
-          </li>
-        ))}
-      </ul>
-      <div className={styles.lastUpdate}>
-        <span className={styles.date}>
-          Last update: {formatDate(indicator.updated_at)}
-        </span>
-        <InfoButton dark slugs="" infoModalData={infoModalData} />
-      </div>
+const TextDisplay = ({ indicator }) => (
+  <div className={styles.textProgress}>
+    <div className={styles.indicatorTitle}>{indicator.title}</div>
+    <ul>
+      {indicator.progress_records.map(progress => (
+        <li key={progress.value}>
+          <ReactMarkdown source={progress.value} escapeHtml={false} />
+        </li>
+      ))}
+    </ul>
+    <div className={styles.lastUpdate}>
+      <span className={styles.date}>
+        Last update: {formatDate(indicator.updated_at)}
+      </span>
+      <InfoButton dark infoModalData={indicator.infoModalData} />
     </div>
-  );
-};
+  </div>
+);
 
 TextDisplay.propTypes = { indicator: PropTypes.object.isRequired };
 

--- a/app/javascript/app/pages/climate-policies/progress/text-display/text-display-component.jsx
+++ b/app/javascript/app/pages/climate-policies/progress/text-display/text-display-component.jsx
@@ -7,26 +7,34 @@ import InfoButton from 'components/info-button';
 
 import styles from './text-display-styles';
 
-const TextDisplay = ({ indicator }) => (
-  <div className={styles.textProgress}>
-    <div className={styles.indicatorTitle}>
-      {indicator.title}
+const TextDisplay = ({ indicator }) => {
+  const tabTitles =
+    indicator && indicator.sources && indicator.sources.map(({ code }) => code);
+  const infoModalData = {
+    data: indicator ? indicator.sources : [],
+    title: 'Sources',
+    tabTitles
+  };
+
+  return (
+    <div className={styles.textProgress}>
+      <div className={styles.indicatorTitle}>{indicator.title}</div>
+      <ul>
+        {indicator.progress_records.map(progress => (
+          <li key={progress.value}>
+            <ReactMarkdown source={progress.value} escapeHtml={false} />
+          </li>
+        ))}
+      </ul>
+      <div className={styles.lastUpdate}>
+        <span className={styles.date}>
+          Last update: {formatDate(indicator.updated_at)}
+        </span>
+        <InfoButton dark slugs="" infoModalData={infoModalData} />
+      </div>
     </div>
-    <ul>
-      {indicator.progress_records.map(progress => (
-        <li key={progress.value}>
-          <ReactMarkdown source={progress.value} escapeHtml={false} />
-        </li>
-      ))}
-    </ul>
-    <div className={styles.lastUpdate}>
-      <span className={styles.date}>
-        Last update: {formatDate(indicator.updated_at)}
-      </span>
-      <InfoButton dark slugs="" />
-    </div>
-  </div>
-);
+  );
+};
 
 TextDisplay.propTypes = { indicator: PropTypes.object.isRequired };
 

--- a/app/javascript/app/selectors/climate-policies-selectors.js
+++ b/app/javascript/app/selectors/climate-policies-selectors.js
@@ -82,8 +82,16 @@ export const getIndicatorsProgress = createSelector(
     const indicatorsWithSoures = sortedIndicators.map(indicator => {
       const filteredSources = sources.filter(({ id }) =>
         indicator.source_ids.includes(id));
+      const sourcesModalData = filteredSources.map(
+        ({ code, name, description, link }) => ({
+          code,
+          name,
+          description,
+          link
+        })
+      );
       const infoModalData = {
-        data: filteredSources,
+        data: sourcesModalData,
         title: 'Sources',
         tabTitles: filteredSources.map(({ code }) => code)
       };

--- a/app/javascript/app/selectors/climate-policies-selectors.js
+++ b/app/javascript/app/selectors/climate-policies-selectors.js
@@ -82,7 +82,12 @@ export const getIndicatorsProgress = createSelector(
     const indicatorsWithSoures = sortedIndicators.map(indicator => {
       const filteredSources = sources.filter(({ id }) =>
         indicator.source_ids.includes(id));
-      return { ...indicator, sources: filteredSources };
+      const infoModalData = {
+        data: filteredSources,
+        title: 'Sources',
+        tabTitles: filteredSources.map(({ code }) => code)
+      };
+      return { ...indicator, infoModalData };
     });
     return indicatorsWithSoures;
   }

--- a/app/javascript/app/selectors/climate-policies-selectors.js
+++ b/app/javascript/app/selectors/climate-policies-selectors.js
@@ -69,14 +69,22 @@ export const getMilestones = createSelector(
 );
 
 export const getIndicatorsProgress = createSelector(
-  [getClimatePolicyDetails, getPolicyCode],
-  (policyDetails, policyCode) => {
-    if (!policyDetails || !policyCode) return null;
+  [getClimatePolicyDetails, getPolicyCode, getSources],
+  (policyDetails, policyCode, sources) => {
+    if (!policyDetails || !policyCode || !sources) return null;
 
     const indicators =
       policyDetails &&
       policyDetails.indicators.filter(i => !!i.progress_display);
-    return policyCode === 'CEC' ? sortBy(indicators, ['title']) : indicators;
+    const sortedIndicators =
+      policyCode === 'CEC' ? sortBy(indicators, ['title']) : indicators;
+
+    const indicatorsWithSoures = sortedIndicators.map(indicator => {
+      const filteredSources = sources.filter(({ id }) =>
+        indicator.source_ids.includes(id));
+      return { ...indicator, sources: filteredSources };
+    });
+    return indicatorsWithSoures;
   }
 );
 


### PR DESCRIPTION
This PR enables info modals in Climate Policies/Snapshot of progress.
[PIVOTAL](https://www.pivotaltracker.com/story/show/165491313) | [BASECAMP](https://launchpad.37signals.com/basecamp/1740100/signin#comment_694031709)