### PR TITLE
Update cw-components to 1.56.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "compression-webpack-plugin": "1.0.0",
     "core-js": "2.5.3",
     "css-loader": "0.28.7",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.50.1",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.56.1",
     "directory-named-webpack-plugin": "4.0.0",
     "dotenv": "4.0.0",
     "es6-promise": "^4.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3043,9 +3043,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.50.1":
-  version "1.50.1"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/7969dd0014d8d31778a5a822bb4a9742bcadd8d6"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.56.1":
+  version "1.56.1"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/ba2cec6f908c8d723b5b11fa752d9ba45d031916"
   dependencies:
     "@d3fc/d3fc-discontinuous-scale" "^3.0.7"
     "@latticejs/recharts-sunburst" "^1.0.1-beta.0"


### PR DESCRIPTION
This PR updates the `cw-components` version to 1.56.1 what fixes the bug with carousel component - the error occurs on less performant devices and/or slow connection:
**BUG:**
![fygze-ig8ab](https://user-images.githubusercontent.com/15097138/73754264-08e4d800-475c-11ea-96b2-afca0233ecbb.gif)

**NOTE**: Before start run `yarn install`